### PR TITLE
Add GAME_STATE_DATABASE_HOST_URL to turbo

### DIFF
--- a/packages/api/src/availableServices.ts
+++ b/packages/api/src/availableServices.ts
@@ -5,9 +5,11 @@ import {
   TileGameServiceDefinition,
   TileMapServiceDefinition
 } from "./services/games/snatch-the-snack";
+import { GameStateApi, GameStateServiceDefinition } from "./services/gameState";
 import { HealthServiceApi, HealthServiceDefinition } from "./services/health";
 
 export type AvailableServices = {
+  gameState: GameStateApi;
   health: HealthServiceApi;
   snatchTheSnackMaps: TileMapServiceApi;
   tileGame: TileGameServiceApi;
@@ -18,6 +20,7 @@ export type AvailbleServicesDefinition = {
 };
 
 export const AVAILABLE_SERVICES: AvailbleServicesDefinition = {
+  gameState: GameStateServiceDefinition,
   health: HealthServiceDefinition,
   snatchTheSnackMaps: TileMapServiceDefinition,
   tileGame: TileGameServiceDefinition

--- a/packages/backend/turbo.json
+++ b/packages/backend/turbo.json
@@ -3,12 +3,14 @@
     "tasks": {
         "build": {
             "env": [
-                "DATABASE_HOST_URL"
+                "DATABASE_HOST_URL",
+                "GAME_STATE_DATABASE_HOST_URL"
             ]
         },
         "dev": {
             "env": [
-                "DATABASE_HOST_URL"
+                "DATABASE_HOST_URL",
+                "GAME_STATE_DATABASE_HOST_URL"
             ]
         }
     }


### PR DESCRIPTION
Whoops, without the turbo change the server is crashing.

---

This pull request introduces changes to integrate the new `GameState` service into the existing codebase and updates the environment configuration to support it.

### Integration of GameState service:

* [`packages/api/src/availableServices.ts`](diffhunk://#diff-eab97250cc59071dadea79b11e2c2bb877e4a1c04bc5b167dfd7c8331eaf31fdR8-R12): Added `GameStateApi` and `GameStateServiceDefinition` imports and included `gameState` in the `AvailableServices` type.
* [`packages/api/src/availableServices.ts`](diffhunk://#diff-eab97250cc59071dadea79b11e2c2bb877e4a1c04bc5b167dfd7c8331eaf31fdR23): Updated `AVAILABLE_SERVICES` to include `gameState` with `GameStateServiceDefinition`.

### Environment configuration updates:

* [`packages/backend/turbo.json`](diffhunk://#diff-29bf0302cac0fc77a29f34f6ff72ad44f714f74c48f3f59cd5dd91feee64e97fL6-R13): Added `GAME_STATE_DATABASE_HOST_URL` to the environment variables for both `build` and `dev` tasks.