### PR TITLE
Add backend for players joining a game

### DIFF
--- a/packages/api/src/services/gameState/gameStateService.ts
+++ b/packages/api/src/services/gameState/gameStateService.ts
@@ -33,6 +33,18 @@ export interface AvailableGames {
   games: AvailableGame[];
 }
 
+export interface JoinGame {
+  gameId: GameId;
+  gameType: GameType;
+  playerId: PlayerId;
+}
+
+export interface LeaveGame {
+  gameId: GameId;
+  gameType: GameType;
+  playerId: PlayerId;
+}
+
 export interface UpdateGameResponse {
   didAcceptChange: boolean;
   newGameState: GameStateAndInfo;
@@ -51,6 +63,14 @@ export interface GameStateApi extends Service {
     payload: GetGameState;
     response: GameStateAndInfo;
   };
+  joinGame: {
+    payload: JoinGame;
+    response: GameStateAndInfo;
+  };
+  leaveGame: {
+    payload: LeaveGame;
+    response: Record<string, never>;
+  };
   updateGame: {
     payload: UpdateGame;
     response: UpdateGameResponse;
@@ -64,6 +84,8 @@ export const GameStateServiceDefinition: ServiceDefinition<GameStateApi> = {
     createGame: "create-game",
     getAvailableGames: "get-available-games",
     getGameState: "get-game-state",
+    joinGame: "join-game",
+    leaveGame: "leave-game",
     updateGame: "update-game"
   }
 };

--- a/packages/backend/src/gameState/gameState.controller.ts
+++ b/packages/backend/src/gameState/gameState.controller.ts
@@ -4,6 +4,8 @@ import {
   GameStateApi,
   GameStateServiceDefinition,
   GetGameState,
+  JoinGame,
+  LeaveGame,
   UpdateGame
 } from "@resync-games/api";
 import {
@@ -31,6 +33,16 @@ export class GameStateController
   @getDecorator(GameStateServiceDefinition.endpoints.getGameState)
   public async getGameState(@Body() request: GetGameState) {
     return this.gameStateService.getGameState(request);
+  }
+
+  @getDecorator(GameStateServiceDefinition.endpoints.joinGame)
+  public async joinGame(@Body() request: JoinGame) {
+    return this.gameStateService.joinGame(request);
+  }
+
+  @getDecorator(GameStateServiceDefinition.endpoints.leaveGame)
+  public async leaveGame(@Body() request: LeaveGame) {
+    return this.gameStateService.leaveGame(request);
   }
 
   @getDecorator(GameStateServiceDefinition.endpoints.updateGame)

--- a/packages/frontend/src/components/inGame/GetGameState.tsx
+++ b/packages/frontend/src/components/inGame/GetGameState.tsx
@@ -1,3 +1,4 @@
+import { Flex } from "@/lib/radix/Flex";
 import { ClientServiceCallers } from "@/services/serviceCallers";
 import {
   GameId,
@@ -5,11 +6,10 @@ import {
   GameType,
   isServiceError
 } from "@resync-games/api";
-import { redirect } from "next/navigation";
 import { useContext, useEffect, useState } from "react";
 import { PlayerContext } from "../player/PlayerContext";
 import { InitializeGame } from "./InitializeGame";
-import { Flex } from "@/lib/radix/Flex";
+import { useRouter } from "next/navigation";
 
 export const GetGameState = ({
   gameId,
@@ -19,6 +19,7 @@ export const GetGameState = ({
   gameSlug: GameType;
 }) => {
   const player = useContext(PlayerContext);
+  const router = useRouter();
 
   const [gameStateAndInfo, setGameStateAndInfo] =
     useState<GameStateAndInfo | null>(null);
@@ -30,7 +31,8 @@ export const GetGameState = ({
       playerId: player.playerId
     });
     if (isServiceError(gameStateAndInfo)) {
-      redirect("/");
+      router.push("/");
+      return;
     }
 
     setGameStateAndInfo(gameStateAndInfo);


### PR DESCRIPTION
This pull request introduces new functionality to manage players joining and leaving games, along with some frontend adjustments. The most important changes include adding new interfaces and API endpoints for joining and leaving games, updating the backend service and controller to handle these actions, and modifying the frontend to use the new router navigation method.

### Backend Changes:

* **New Interfaces and API Endpoints:**
  - Added `JoinGame` and `LeaveGame` interfaces to `gameStateService.ts` (`packages/api/src/services/gameState/gameStateService.ts`).
  - Updated `GameStateApi` to include `joinGame` and `leaveGame` endpoints (`packages/api/src/services/gameState/gameStateService.ts`).
  - Updated `GameStateServiceDefinition` to map new endpoints (`packages/api/src/services/gameState/gameStateService.ts`).

* **Controller and Service Updates:**
  - Imported `JoinGame` and `LeaveGame` in `gameState.controller.ts` and added methods to handle these endpoints (`packages/backend/src/gameState/gameState.controller.ts`) [[1]](diffhunk://#diff-174a5aec7de488a75ae32abc61d2b08584bba6592dbc50b6186f5b4fbdf72902R7-R8) [[2]](diffhunk://#diff-174a5aec7de488a75ae32abc61d2b08584bba6592dbc50b6186f5b4fbdf72902R38-R47).
  - Implemented `joinGame` and `leaveGame` methods in `gameState.service.ts` to handle the logic for joining and leaving games (`packages/backend/src/gameState/gameState.service.ts`) [[1]](diffhunk://#diff-7331583625bea06bcfa56e259fe780af59adbeeaf92d5d3fc7db88533c82d326R7-R8) [[2]](diffhunk://#diff-7331583625bea06bcfa56e259fe780af59adbeeaf92d5d3fc7db88533c82d326R130-R229).

### Frontend Changes:

* **Router Navigation Update:**
  - Imported `useRouter` from `next/navigation` and replaced `redirect` with `router.push` in `GetGameState.tsx` to handle navigation (`packages/frontend/src/components/inGame/GetGameState.tsx`) [[1]](diffhunk://#diff-b3ff7308edbc2dc2a6e1d941f4e9d33bc35f6bea2daa8006ba2b82ef386f912eR1-R12) [[2]](diffhunk://#diff-b3ff7308edbc2dc2a6e1d941f4e9d33bc35f6bea2daa8006ba2b82ef386f912eR22) [[3]](diffhunk://#diff-b3ff7308edbc2dc2a6e1d941f4e9d33bc35f6bea2daa8006ba2b82ef386f912eL33-R35).