### PR TITLE
Flush out backend ticking

### DIFF
--- a/packages/api/src/services/gameState/gameStateService.ts
+++ b/packages/api/src/services/gameState/gameStateService.ts
@@ -25,7 +25,7 @@ export interface UpdateGame {
   gameId: GameId;
   lastUpdatedAt: string;
   newGameState: object;
-  playerId: PlayerId;
+  playerId?: PlayerId;
   version: string;
 }
 

--- a/packages/backend/src/gameState/gameState.module.ts
+++ b/packages/backend/src/gameState/gameState.module.ts
@@ -9,6 +9,7 @@ import { GameRegistryService } from "./utils/gameRegistry.service";
 
 @Module({
   controllers: [GameStateController],
+  exports: [GameStateService, GameRegistryService],
   imports: [ResyncGamesPrismaModule, UserModule],
   providers: [
     GameStateService,

--- a/packages/backend/src/gameState/ticker/gameStateTicker.module.ts
+++ b/packages/backend/src/gameState/ticker/gameStateTicker.module.ts
@@ -1,7 +1,10 @@
 import { Module } from "@nestjs/common";
 import { GameStateTicker } from "./gameStateTicker.service";
+import { GameStateModule } from "../gameState.module";
+import { ResyncGamesPrismaModule } from "@/database/resyncGamesPrisma.module";
 
 @Module({
+  imports: [GameStateModule, ResyncGamesPrismaModule],
   providers: [GameStateTicker]
 })
 export class GameStateTickerModule {}

--- a/packages/backend/src/gameState/ticker/gameStateTicker.service.ts
+++ b/packages/backend/src/gameState/ticker/gameStateTicker.service.ts
@@ -1,12 +1,68 @@
+import { ResyncGamesPrismaService } from "@/database/resyncGamesPrisma.service";
 import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
+import { GameStateAndInfo } from "@resync-games/api";
+import { GameStateService } from "../gameState.service";
+import { GameRegistryService } from "../utils/gameRegistry.service";
 
 @Injectable()
 export class GameStateTicker {
   public logger = new Logger("Game state ticker");
 
+  public constructor(
+    private prismaService: ResyncGamesPrismaService,
+    private gameStateService: GameStateService,
+    private gameRegistryService: GameRegistryService
+  ) {}
+
   @Cron(CronExpression.EVERY_5_SECONDS)
-  public tick() {
-    this.logger.log("Tick");
+  public async tick() {
+    const gamesInFlight = await this.prismaService.client.gameState.findMany({
+      include: {
+        PlayersInGame: {
+          include: {
+            player: true
+          }
+        }
+      },
+      where: {
+        currentGameState: "playing"
+      }
+    });
+
+    if (gamesInFlight.length === 0) {
+      this.logger.log(
+        `Ticking on ${new Date().toLocaleString()}. No games active, skipping.`
+      );
+      return;
+    }
+
+    this.logger.log(
+      `Ticking on ${new Date().toLocaleString()} for ${gamesInFlight.length} games`
+    );
+    for (const game of gamesInFlight) {
+      this.tickGame(
+        this.prismaService.converterService.convertGameState(
+          game,
+          game.PlayersInGame.map((p) => p.player),
+          game.PlayersInGame
+        )
+      );
+    }
   }
+
+  private tickGame = async (game: GameStateAndInfo) => {
+    const backend = this.gameRegistryService.getGameRegistry(game.gameType);
+    const maybeNewGameState = backend?.tickGameState?.(game);
+    if (maybeNewGameState === undefined) {
+      return;
+    }
+
+    await this.gameStateService.updateGame({
+      gameId: game.gameId,
+      lastUpdatedAt: new Date().toISOString(),
+      newGameState: maybeNewGameState,
+      version: game.version
+    });
+  };
 }

--- a/packages/games/src/backend/base.ts
+++ b/packages/games/src/backend/base.ts
@@ -1,6 +1,7 @@
 import {
   CreateGame,
   CurrentGameState,
+  GameStateAndInfo,
   Player,
   PlayerInGame
 } from "@resync-games/api";
@@ -46,4 +47,10 @@ export interface IGameServer<GameState> {
    * Callback on when a player leaves the game. Useful if you want to clean up the player's state.
    */
   onPlayerLeave?: (game: GameState, player: Player) => GameState;
+  /**
+   * Callback every 5 seconds that allows the backend to modify the game state as required. If it returns
+   * undefined, the server will leave the current game state alone. All game state updates will be broadcast
+   * to all players.
+   */
+  tickGameState?: (gameStateAndInfo: GameStateAndInfo) => GameState | undefined;
 }


### PR DESCRIPTION
This pull request includes several changes to the game state management system, focusing on enhancing the game state ticker functionality and improving module imports and service injections.

Fix: https://github.com/kadhirvelm/resync-games/issues/89

### Enhancements to game state ticker functionality:
* [`packages/backend/src/gameState/ticker/gameStateTicker.service.ts`](diffhunk://#diff-8ffc64c4e36c7a72cb0819a1d7bbf572cd7a0eb3b6a4a8122b45c9ece7968703R1-R67): Added new dependencies and implemented logic to handle game state updates every 5 seconds, including fetching active games and updating their states.

### Module imports and service injections:
* [`packages/backend/src/gameState/ticker/gameStateTicker.module.ts`](diffhunk://#diff-69043d0f06e78b4e10158ad53691dbecc67b433d16aa5065d38d5837093da10eR3-R7): Imported `GameStateModule` and `ResyncGamesPrismaModule` to support the ticker service.
* [`packages/backend/src/gameState/gameState.module.ts`](diffhunk://#diff-e8d141a10563b512838d65a506c7d9f3abb57e3fc63c83b26291e169edfb7bafR12): Exported `GameStateService` and `GameRegistryService` to make them available for other modules.

### Interface updates:
* [`packages/api/src/services/gameState/gameStateService.ts`](diffhunk://#diff-226cc455cb40155faebb6005eaf432c7b57f6cf322ac2c70b06f065ea3c8df67L28-R28): Made `playerId` optional in the `UpdateGame` interface.
* [`packages/games/src/backend/base.ts`](diffhunk://#diff-08b94020b28c8ae196b306c7c766ddc1ff1a8a46819c77a72791d63f9f1dcf45R50-R55): Added `tickGameState` callback to the `IGameServer` interface to allow periodic game state updates.