### PR TITLE
Display sell stock

### DIFF
--- a/packages/backend/src/gameState/utils/gamesInFlight.service.ts
+++ b/packages/backend/src/gameState/utils/gamesInFlight.service.ts
@@ -100,8 +100,6 @@ export class GamesInFlightService {
       reconcilerMethod
     );
 
-    console.log(JSON.stringify(newState));
-
     if (!didAcceptChange) {
       return { didAcceptChange: false, newGameState: previousGameState };
     }

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.module.scss
@@ -4,6 +4,7 @@
     border-radius: 5px;
     background: vars.$white;
     border: 1px solid vars.$muted-font;
+    overflow-y: auto;
 }
 
 .divider {

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
@@ -1,15 +1,13 @@
-import { Flex, Text } from "../../components";
-import { selectPlayerPortfolio, selectTeams } from "../store/selectors";
-import { useGameStateSelector } from "../store/theStockTimesRedux";
-import { displayDollar } from "../utils/displayDollar";
+import { Flex, Text } from "../../../components";
+import { selectPlayerPortfolio, selectTeams } from "../../store/selectors";
+import { useGameStateSelector } from "../../store/theStockTimesRedux";
+import { displayDollar } from "../../utils/displayDollar";
 import styles from "./PlayerPortfolio.module.scss";
+import { PlayerStocks } from "./PlayerStocks";
 
 export const PlayerPortfolio = () => {
   const { player } = useGameStateSelector((s) => s.playerSlice);
   const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
-  const stocks = useGameStateSelector(
-    (s) => s.gameStateSlice.gameState?.stocks
-  );
 
   const teams = useGameStateSelector(selectTeams);
   const playerTeam = teams[playerPortfolio?.team ?? 0];
@@ -48,11 +46,6 @@ export const PlayerPortfolio = () => {
   const renderYourPortfolio = () => {
     return (
       <>
-        <Flex mt="2">
-          <Text color="gray" size="2">
-            Your portfolio
-          </Text>
-        </Flex>
         <Flex align="center" gap="3">
           <Flex>
             <Text>Cash</Text>
@@ -68,42 +61,6 @@ export const PlayerPortfolio = () => {
     );
   };
 
-  const renderYourStocks = () => {
-    const playerStocks = Object.entries(playerPortfolio.ownedStocks);
-
-    return (
-      <>
-        {playerStocks.map(([symbol, quantity]) => {
-          const stock = stocks?.[symbol];
-          return (
-            <Flex direction="column" key={symbol}>
-              <Flex>
-                <Text>
-                  {stock?.title} ({symbol})
-                </Text>
-              </Flex>
-              <Flex direction="column" gap="2">
-                {quantity.map(({ price, quantity }, index) => (
-                  <Flex key={`${symbol}-${index}`}>
-                    <Flex>
-                      <Text>{quantity}</Text>
-                    </Flex>
-                    <Flex>
-                      <Text color="gray" size="2">
-                        bought at
-                      </Text>
-                      <Text>${price}</Text>
-                    </Flex>
-                  </Flex>
-                ))}
-              </Flex>
-            </Flex>
-          );
-        })}
-      </>
-    );
-  };
-
   return (
     <Flex
       className={styles.portfolioContainer}
@@ -113,8 +70,13 @@ export const PlayerPortfolio = () => {
       p="3"
     >
       {renderTeamValue()}
+      <Flex mt="2">
+        <Text color="gray" size="2">
+          Your portfolio
+        </Text>
+      </Flex>
       {renderYourPortfolio()}
-      {renderYourStocks()}
+      <PlayerStocks />
     </Flex>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.module.scss
@@ -1,0 +1,19 @@
+@use "@/styles/variables.scss" as vars;
+
+.holding {
+    border-radius: 3px;
+    border: 1px solid vars.$muted-font;
+}
+
+.holdingAction {
+    border-bottom: 1px solid vars.$muted-font;
+}
+
+.equals {
+    border-bottom: 1px solid vars.$muted-font;
+}
+
+.divider {
+    background: vars.$muted-font;
+    height: 1px;
+}

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
@@ -1,0 +1,182 @@
+import { selectPlayerPortfolio } from "../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { Button, Flex, Text } from "../../../components";
+import { displayDollar } from "../../utils/displayDollar";
+import styles from "./PlayerStocks.module.scss";
+import {
+  OwnedStock,
+  TransactionHistory
+} from "../../../../backend/theStockTimes/theStockTimes";
+
+const SellPlayerStock = ({
+  currentPrice,
+  ownedStock,
+  symbol
+}: {
+  currentPrice: number;
+  ownedStock: OwnedStock;
+  symbol: string;
+}) => {
+  const dispatch = useGameStateDispatch();
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+
+  const onSell = () => {
+    if (player === undefined || playerPortfolio === undefined) {
+      return;
+    }
+
+    const newCash = playerPortfolio.cash + currentPrice * ownedStock.quantity;
+    const newOwnedStock = playerPortfolio.ownedStocks[symbol]?.filter(
+      (stock) => stock.date !== ownedStock.date
+    );
+
+    const newTransaction: TransactionHistory = {
+      date: new Date().toISOString(),
+      price: currentPrice,
+      quantity: ownedStock.quantity,
+      stockSymbol: symbol,
+      type: "sell"
+    };
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          players: {
+            [player.playerId]: {
+              cash: newCash,
+              lastUpdatedAt: new Date().toISOString(),
+              ownedStocks: {
+                ...playerPortfolio.ownedStocks,
+                [symbol]: newOwnedStock
+              },
+              transactionHistory: [
+                ...playerPortfolio.transactionHistory,
+                newTransaction
+              ]
+            }
+          }
+        },
+        player
+      )
+    );
+  };
+
+  return (
+    <Button color="red" onClick={onSell}>
+      Sell
+    </Button>
+  );
+};
+
+export const PlayerStocks = () => {
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+  const stocks = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.stocks
+  );
+
+  if (playerPortfolio === undefined) {
+    return;
+  }
+
+  const playerStocksSorted = Object.keys(playerPortfolio.ownedStocks)
+    .slice()
+    .sort();
+
+  return playerStocksSorted.map((symbol) => {
+    const ownedStock = playerPortfolio.ownedStocks[symbol];
+    if (ownedStock === undefined || ownedStock.length === 0) {
+      return;
+    }
+
+    const stock = stocks?.[symbol];
+
+    const currentPrice = stock?.history[0]?.price ?? 0;
+    const totalQuantity = ownedStock.reduce(
+      (previous, next) => previous + next.quantity,
+      0
+    );
+    const totalPrice = totalQuantity * currentPrice;
+
+    const sortedQuantity = ownedStock
+      .slice()
+      .sort((a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf());
+
+    return (
+      <Flex direction="column" key={symbol}>
+        <Flex align="center" gap="3">
+          <Text>{symbol}</Text>
+          <Flex className={styles.divider} flex="1" />
+          <Text color="green">{displayDollar(totalPrice)}</Text>
+        </Flex>
+        <Flex direction="column" gap="4" ml="3" mt="2">
+          {sortedQuantity.map((ownedStock, index) => {
+            const { price, quantity } = ownedStock;
+            const costBasis = price * quantity;
+            const revenue = currentPrice * quantity;
+            const totalProfit = revenue - costBasis;
+
+            return (
+              <Flex
+                className={styles.holding}
+                direction="column"
+                gap="1"
+                key={`${symbol}-${index}`}
+              >
+                <Flex
+                  align="center"
+                  className={styles.holdingAction}
+                  gap="4"
+                  justify="between"
+                  p="2"
+                >
+                  <Flex align="center" gap="2">
+                    <Flex>
+                      <Text>{quantity.toLocaleString()}</Text>
+                    </Flex>
+                    <Text color="gray" size="2">
+                      at
+                    </Text>
+                    <Text color="green">{displayDollar(price)}</Text>
+                  </Flex>
+                  <SellPlayerStock
+                    currentPrice={currentPrice}
+                    ownedStock={ownedStock}
+                    symbol={symbol}
+                  />
+                </Flex>
+                <Flex align="end" direction="column" gap="1" px="2" py="1">
+                  <Flex align="center" gap="1">
+                    <Text color="green">{displayDollar(revenue)}</Text>
+                    <Text color="gray" size="2">
+                      (revenue)
+                    </Text>
+                  </Flex>
+                  <Flex align="center" className={styles.equals} gap="1">
+                    <Text color="red">-{displayDollar(costBasis)}</Text>
+                    <Text color="gray" size="2">
+                      (cost basis)
+                    </Text>
+                  </Flex>
+                  <Flex align="center" gap="1" mt="1">
+                    <Text color="gray" size="2">
+                      (profit)
+                    </Text>
+                    <Text>=</Text>
+                    <Text color={totalProfit > 0 ? "green" : "red"} size="4">
+                      {displayDollar(totalProfit)}
+                    </Text>
+                  </Flex>
+                </Flex>
+              </Flex>
+            );
+          })}
+        </Flex>
+      </Flex>
+    );
+  });
+};

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
@@ -66,6 +66,7 @@ export const PurchaseStock = ({
               cash: leftOverCash,
               lastUpdatedAt: new Date().toISOString(),
               ownedStocks: {
+                ...playerPortfolio.ownedStocks,
                 [viewingStockSymbol]: [
                   ...(playerPortfolio.ownedStocks[viewingStockSymbol] ?? []),
                   newOwnedStock

--- a/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
@@ -1,6 +1,6 @@
 import { Flex, Text } from "../components";
 import { AvailableStocks } from "./components/AvailableStocks";
-import { PlayerPortfolio } from "./components/PlayerPortfolio";
+import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 import styles from "./TheStockTimes.module.scss";
 


### PR DESCRIPTION
This pull request includes significant updates to the `PlayerPortfolio` component and related files to improve the structure and functionality of the portfolio display in the game. The changes include renaming and restructuring files, adding a new `PlayerStocks` component, and updating styles.

### Component Restructuring:

* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx`](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L1-L12): Refactored to use the new `PlayerStocks` component for displaying player stocks and moved the "Your portfolio" heading to a new position. Removed the `renderYourStocks` function. [[1]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L1-L12) [[2]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L51-L55) [[3]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L71-L106) [[4]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R73-R79)
* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx`](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeR1-R182): Added a new component to handle the display and functionality of player stocks, including a `SellPlayerStock` subcomponent for selling stocks.

### File Renaming and Import Updates:

* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.module.scss`](diffhunk://#diff-b0c36e40f07289cdd090728f077299cc4f9bf0c7350800597542555886ad3abaR7): Renamed from `PlayerPortfolio.module.scss` and added overflow styling.
* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx`](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L1-L12): Updated import paths to reflect the new file structure.
* [`packages/games/src/frontend/theStockTimes/theStockTimes.tsx`](diffhunk://#diff-24580a30d72b6158eb4069bf61cdc2ab7aa4d7e38b3ede36ad8655dbcd0db8b3L3-R3): Updated import path for `PlayerPortfolio` to reflect the new file structure.

### Style Enhancements:

* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.module.scss`](diffhunk://#diff-8a4c945db39fc73d1a52b457eb7403402473918f03876ab5f95af0ff5f22a31bR1-R19): Added new styles for the `PlayerStocks` component, including styles for holdings and dividers.

### Bug Fixes:

* [`packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx`](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396R69): Fixed a bug where the `ownedStocks` property was not being correctly spread when purchasing a stock.

These changes collectively enhance the maintainability and functionality of the `PlayerPortfolio` component, providing a more modular and organized codebase.