### PR TITLE
Add game clock

### DIFF
--- a/packages/api/src/genericTypes/index.ts
+++ b/packages/api/src/genericTypes/index.ts
@@ -2,3 +2,4 @@ export * from "./error";
 export * from "./removeExtendsString";
 export * from "./service";
 export * from "./socket";
+export * from "./stateReconciliation";

--- a/packages/api/src/genericTypes/stateReconciliation.ts
+++ b/packages/api/src/genericTypes/stateReconciliation.ts
@@ -1,0 +1,18 @@
+/**
+ * Uses the `lastUpdatedAt` field to determine which state to reconcile.
+ */
+export interface WithTimestamp {
+  lastUpdatedAt: string;
+}
+
+/**
+ * A nested object with `lastUpdatedAt` fields.
+ */
+export interface NestedTimestamp {
+  [key: string]: WithTimestamp;
+}
+
+/**
+ * An object with a `lastUpdatedAt` field.
+ */
+export type TimestampedState = WithTimestamp | NestedTimestamp;

--- a/packages/api/src/services/gameState/gameStateService.ts
+++ b/packages/api/src/services/gameState/gameStateService.ts
@@ -1,3 +1,4 @@
+import { WithTimestamp } from "../../genericTypes";
 import { Service, ServiceDefinition } from "../../genericTypes/service";
 import { PlayerId } from "../user";
 import {
@@ -21,9 +22,8 @@ export interface CreateGame<GameConfiguration = object> {
   version: string;
 }
 
-export interface UpdateGame {
+export interface UpdateGame extends WithTimestamp {
   gameId: GameId;
-  lastUpdatedAt: string;
   newGameState: object;
   playerId?: PlayerId;
   version: string;
@@ -64,11 +64,11 @@ export interface UpdatePlayerInGame {
   team?: number;
 }
 
-export interface UpdateGameConfiguration<GameConfiguration = object> {
+export interface UpdateGameConfiguration<GameConfiguration = object>
+  extends WithTimestamp {
   gameConfiguration: GameConfiguration;
   gameId: GameId;
   gameType: GameType;
-  lastUpdatedAt: string;
   playerId: PlayerId;
 }
 

--- a/packages/api/src/services/gameState/gameStateTypes.ts
+++ b/packages/api/src/services/gameState/gameStateTypes.ts
@@ -1,3 +1,4 @@
+import { WithTimestamp } from "../../genericTypes";
 import { Player } from "../user";
 
 export type GameId = string & { __brand: "game-id" };
@@ -9,13 +10,12 @@ export interface PlayerInGame extends Player {
   team?: number;
 }
 
-export interface GameInfo<GameConfiguration = object> {
+export interface GameInfo<GameConfiguration = object> extends WithTimestamp {
   currentGameState: CurrentGameState;
   gameConfiguration: GameConfiguration;
   gameId: GameId;
   gameName: string;
   gameType: GameType;
-  lastUpdatedAt: string;
   players: PlayerInGame[];
   version: string;
 }

--- a/packages/backend/src/gameState/utils/gamesInFlight.service.ts
+++ b/packages/backend/src/gameState/utils/gamesInFlight.service.ts
@@ -1,5 +1,10 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
-import { GameId, GameStateAndInfo, GameType } from "@resync-games/api";
+import {
+  GameId,
+  GameStateAndInfo,
+  GameType,
+  TimestampedState
+} from "@resync-games/api";
 import * as _ from "lodash";
 import { ResyncGamesPrismaService } from "../../database/resyncGamesPrisma.service";
 import { GameStateSocketGateway } from "../gameState.socket";
@@ -9,7 +14,7 @@ import {
   BackendRegisteredGame,
   StateReconcilerMethod
 } from "@resync-games/games/backendRegistry";
-import { reconcileStates, TimestampedState } from "./reconcileStates";
+import { reconcileStates } from "./reconcileStates";
 
 @Injectable()
 export class GamesInFlightService {

--- a/packages/backend/src/gameState/utils/reconcileStates.ts
+++ b/packages/backend/src/gameState/utils/reconcileStates.ts
@@ -1,14 +1,5 @@
+import { WithTimestamp, NestedTimestamp } from "@resync-games/api";
 import { StateReconcilerMethod } from "@resync-games/games/backendRegistry";
-
-export interface WithTimestamp {
-  lastUpdatedAt: string;
-}
-
-export interface NestedTimestamp {
-  [key: string]: WithTimestamp;
-}
-
-export type TimestampedState = WithTimestamp | NestedTimestamp;
 
 function compareDates(
   dateOne: string | undefined,

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -20,7 +20,8 @@
     "esModuleInterop": true,
     "paths": {
       "@/*": ["./src/*"],
-      "@resync-games/games/*": ["../games/src/backend/*"]
+      "@resync-games/games/*": ["../games/src/backend/*"],
+      "@resync-games/games-shared/*": ["../games/src/shared/*"]
     },
   },
   "include": ["**/*.ts", "../games/src/backend/**/*.ts", "../games/src/shared/**/*.ts"],

--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -1,21 +1,26 @@
 import {
   CurrentGameState,
   GameStateAndInfo,
-  PlayerId
+  PlayerId,
+  WithTimestamp
 } from "@resync-games/api";
 import { ICanChangeToState, IGameServer } from "../base";
 import _ from "lodash";
 import { AVAILABLE_STOCKS } from "./stocks/availableStocks";
 
-export interface StockPriceHistory {
-  lastUpdatedAt: string;
+export interface StockTimesCycle {
+  dayTime: number;
+  nightTime: number;
+  startTime: string;
+}
+
+export interface StockPriceHistory extends WithTimestamp {
   price: number;
 }
 
-export interface Stock {
+export interface Stock extends WithTimestamp {
   description: string;
   history: StockPriceHistory[];
-  lastUpdatedAt: string;
   title: string;
 }
 
@@ -33,17 +38,19 @@ export interface TransactionHistory {
   type: "buy" | "sell";
 }
 
+export interface StockTimesPlayer extends WithTimestamp {
+  cash: number;
+  ownedStocks: {
+    [stockSymbol: string]: OwnedStock[];
+  };
+  team: number;
+  transactionHistory: TransactionHistory[];
+}
+
 export interface TheStockTimesGame {
+  cycle: StockTimesCycle;
   players: {
-    [playerId: PlayerId]: {
-      cash: number;
-      lastUpdatedAt: string;
-      ownedStocks: {
-        [stockSymbol: string]: OwnedStock[];
-      };
-      team: number;
-      transactionHistory: TransactionHistory[];
-    };
+    [playerId: PlayerId]: StockTimesPlayer;
   };
   stocks: {
     [stockSymbol: string]: Stock;
@@ -62,8 +69,15 @@ export class TheStockTimesServer
     gameState: TheStockTimesGame;
     version: string;
   }> {
+    console.log("Creating game @@@");
+
     return {
       gameState: {
+        cycle: {
+          dayTime: 40 * 1_000, // 40 seconds
+          nightTime: 20 * 1_000, // 20 seconds
+          startTime: new Date().toISOString()
+        },
         players: {},
         stocks: {}
       },

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
@@ -1,0 +1,19 @@
+@use "@/styles/variables.scss" as vars;
+
+.baseClock {
+    fill: vars.$white;
+    stroke: vars.$black;
+    stroke-width: 1;
+}
+
+.night {
+    fill: vars.$blue;
+    stroke: vars.$black;
+    stroke-width: 1;
+}
+
+.pointer {
+    stroke: vars.$black;
+    stroke-width: 3;
+    stroke-linecap: round;
+}

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
@@ -1,0 +1,66 @@
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { StockTimesCycle } from "../../../../backend/theStockTimes/theStockTimes";
+import { Flex, Text } from "../../../components";
+import styles from "./Clock.module.scss";
+import { useEffect, useState } from "react";
+
+function calculateNightTimeArc(cycle: StockTimesCycle) {
+  const percentNight = cycle.nightTime / (cycle.dayTime + cycle.nightTime);
+  const angle = percentNight * 360;
+
+  const radius = 20;
+  const centerX = 25;
+  const centerY = 25;
+
+  const endX = centerX + radius * Math.cos((angle - 90) * (Math.PI / 180));
+  const endY = centerY + radius * Math.sin((angle - 90) * (Math.PI / 180));
+
+  const largeArcFlag = angle > 180 ? 1 : 0;
+
+  return `M ${centerX} ${centerY}
+             L ${centerX} ${centerY - radius}
+             A ${radius} ${radius} 0 ${largeArcFlag} 1 ${endX} ${endY}
+             Z`;
+}
+
+function calculateClockPointer(timeFraction: number) {
+  const angle = timeFraction * 360;
+
+  const radius = 18;
+  const centerX = 25;
+  const centerY = 25;
+
+  const endX = centerX + radius * Math.cos((angle - 90) * (Math.PI / 180));
+  const endY = centerY + radius * Math.sin((angle - 90) * (Math.PI / 180));
+
+  return `M ${centerX} ${centerY} L ${endX} ${endY}`;
+}
+
+export const Clock = ({ cycle }: { cycle: StockTimesCycle }) => {
+  const { day, timeFraction } = cycleTime(cycle);
+
+  const [_, setCounter] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCounter((prev) => prev + 1);
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <Flex align="center" gap="1">
+      <Text size="2">Day</Text>
+      <Text size="2">{day}</Text>
+      <svg height={50} width={50}>
+        <circle className={styles.baseClock} cx="25" cy="25" r="20" />
+        <path className={styles.night} d={calculateNightTimeArc(cycle)} />
+        <path
+          className={styles.pointer}
+          d={calculateClockPointer(timeFraction)}
+        />
+      </svg>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
@@ -1,5 +1,6 @@
-import { Flex, Text } from "../components";
+import { Flex } from "../components";
 import { AvailableStocks } from "./components/AvailableStocks";
+import { Clock } from "./components/cycle/Clock";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 import styles from "./TheStockTimes.module.scss";
@@ -13,8 +14,8 @@ export const DisplayTheStockTimes = () => {
 
   return (
     <Flex className={styles.mainContainer} flex="1">
-      <Flex className={styles.gameName}>
-        <Text>The stock times</Text>
+      <Flex align="center" className={styles.gameName} gap="2">
+        <Clock cycle={gameState.cycle} />
       </Flex>
       <Flex flex="1">
         <PlayerPortfolio />

--- a/packages/games/src/shared/theStockTimes/cycleTime.ts
+++ b/packages/games/src/shared/theStockTimes/cycleTime.ts
@@ -1,0 +1,19 @@
+import { StockTimesCycle } from "../../backend/theStockTimes/theStockTimes";
+
+export function cycleTime(cycle: StockTimesCycle) {
+  const currentTime =
+    new Date().valueOf() - new Date(cycle.startTime).valueOf();
+  const totalTimePerDay = cycle.dayTime + cycle.nightTime;
+
+  const day = Math.floor(currentTime / totalTimePerDay) + 1;
+  const time = currentTime % totalTimePerDay;
+  const timeFraction = time / totalTimePerDay;
+  const currentCycle: "day" | "night" = time < cycle.dayTime ? "day" : "night";
+
+  return {
+    currentCycle,
+    day,
+    time,
+    timeFraction
+  };
+}

--- a/packages/games/tsconfig.json
+++ b/packages/games/tsconfig.json
@@ -21,6 +21,7 @@
     "resolveJsonModule": true,
     "paths": {
       "@/*": ["../frontend/src/*"],
+      "@resync-games/games-shared/*": ["./src/shared/*"],
     }
   },
   "include": ["**/*.ts", "**/*.tsx", "../frontend/src/**/*.tsx", "../frontend/src/**/*.ts", "../backend/src/**/*.ts"],


### PR DESCRIPTION
<img width="264" alt="Screenshot 2024-12-26 at 7 29 31 PM" src="https://github.com/user-attachments/assets/44e0c399-85b0-42d1-9b43-f573c65a1e9e" />

Did all the game clock coordination using frontend logic. We have the backend set the initial game start time along with some other parameters, like how long the day night cycles are, then we let the frontend deal with rendering the clock accordingly.

---

This pull request introduces a new `WithTimestamp` interface to standardize the `lastUpdatedAt` field across various modules and implements a new clock component for the frontend. The most important changes include the addition of the `WithTimestamp` interface, updates to existing interfaces to extend `WithTimestamp`, and the implementation of a clock component to display the game cycle.

### Standardizing `lastUpdatedAt` field:

* [`packages/api/src/genericTypes/stateReconciliation.ts`](diffhunk://#diff-8e4eb70e4201a354080174b2d1fe7b6f74a30f664ac69e6d69d12b97828d5e4aR1-R18): Added `WithTimestamp`, `NestedTimestamp`, and `TimestampedState` interfaces to standardize the `lastUpdatedAt` field.
* [`packages/api/src/services/gameState/gameStateService.ts`](diffhunk://#diff-226cc455cb40155faebb6005eaf432c7b57f6cf322ac2c70b06f065ea3c8df67L24-L26): Updated `UpdateGame` and `UpdateGameConfiguration` interfaces to extend `WithTimestamp` and removed the `lastUpdatedAt` field from these interfaces. [[1]](diffhunk://#diff-226cc455cb40155faebb6005eaf432c7b57f6cf322ac2c70b06f065ea3c8df67L24-L26) [[2]](diffhunk://#diff-226cc455cb40155faebb6005eaf432c7b57f6cf322ac2c70b06f065ea3c8df67L67-L71)
* [`packages/api/src/services/gameState/gameStateTypes.ts`](diffhunk://#diff-9078294af0057a30e62b1ff788e50b95d96d90bc96c0b6f3e6ab77af73f4b99eL12-L18): Updated `GameInfo` interface to extend `WithTimestamp` and removed the `lastUpdatedAt` field.
* [`packages/games/src/backend/theStockTimes/theStockTimes.ts`](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L4-L18): Updated `StockPriceHistory`, `Stock`, and `StockTimesPlayer` interfaces to extend `WithTimestamp` and removed the `lastUpdatedAt` field. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L4-L18) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L36-R53)

### Frontend clock component:

* [`packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx`](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eR1-R66): Implemented a new clock component to display the game cycle, including day and night times.
* [`packages/games/src/frontend/theStockTimes/theStockTimes.tsx`](diffhunk://#diff-24580a30d72b6158eb4069bf61cdc2ab7aa4d7e38b3ede36ad8655dbcd0db8b3L16-R18): Integrated the new clock component into the `DisplayTheStockTimes` component.

### Additional changes:

* [`packages/api/src/genericTypes/index.ts`](diffhunk://#diff-fe4fa9147a2137b67dbc9327c88e25efcfd7ac1b1bc328c19f2e314d8dfa4292R5): Added export for `stateReconciliation` module.
* `packages/backend/tsconfig.json` and `packages/games/tsconfig.json`: Updated TypeScript configuration to include new shared paths. [[1]](diffhunk://#diff-0ef2178f19c6d71c14737a5c931795608bec4ae3dbf0f6c50efba82e0520b3cfL23-R24) [[2]](diffhunk://#diff-4faac2d8736366adb8b7ff1a32918d9ae2e3235ea728b8ac1a08be98e96015abR24)