### PR TITLE
Allow viewing the news articles

### DIFF
--- a/packages/backend/src/gameState/ticker/gameStateTicker.service.ts
+++ b/packages/backend/src/gameState/ticker/gameStateTicker.service.ts
@@ -58,13 +58,11 @@ export class GameStateTicker {
       return;
     }
 
-    const { didAcceptChange } = await this.gameStateService.updateGame({
+    await this.gameStateService.updateGame({
       gameId: game.gameId,
       lastUpdatedAt: new Date().toISOString(),
       newGameState: maybeNewGameState,
       version: game.version
     });
-
-    console.log(didAcceptChange);
   };
 }

--- a/packages/games/src/frontend/theStockTimes/components/AvailableStocks.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/AvailableStocks.tsx
@@ -7,6 +7,7 @@ import { Flex, Text } from "../../components";
 import styles from "./AvailableStocks.module.scss";
 import { displayDollar } from "../utils/displayDollar";
 import { SingleStock } from "./singleStock/SingleStock";
+import { StockArticles } from "./singleStock/StockArticles";
 
 export const AvailableStocks = () => {
   const dispatch = useGameStateDispatch();
@@ -59,6 +60,12 @@ export const AvailableStocks = () => {
             <Text color="gray" mt="2" size="2">
               {stock.description}
             </Text>
+            <Flex flex="1" mt="2">
+              <StockArticles
+                disableChangingArticle={true}
+                viewingStockSymbol={stockSymbol}
+              />
+            </Flex>
           </Flex>
         );
       })}

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
@@ -37,7 +37,7 @@ function calculateClockPointer(timeFraction: number) {
 }
 
 export const Clock = ({ cycle }: { cycle: StockTimesCycle }) => {
-  const { day, timeFraction } = cycleTime(cycle);
+  const { currentCycle, day, timeFraction } = cycleTime(cycle);
 
   const [_, setCounter] = useState(0);
 
@@ -51,7 +51,7 @@ export const Clock = ({ cycle }: { cycle: StockTimesCycle }) => {
 
   return (
     <Flex align="center" gap="1">
-      <Text size="2">Day</Text>
+      <Text size="2">{currentCycle === "day" ? "Day" : "Night"}</Text>
       <Text size="2">{day}</Text>
       <svg height={50} width={50}>
         <circle className={styles.baseClock} cx="25" cy="25" r="20" />

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx
@@ -2,6 +2,7 @@ import { Flex } from "../../../components";
 import { useGameStateSelector } from "../../store/theStockTimesRedux";
 import { PriceGraph } from "./PriceGraph";
 import { PurchaseStock } from "./PurchaseStock";
+import { StockArticles } from "./StockArticles";
 import { StockDetails } from "./StockDetails";
 
 export const SingleStock = ({
@@ -24,6 +25,9 @@ export const SingleStock = ({
         thisStock={thisStock}
         viewingStockSymbol={viewingStockSymbol}
       />
+      <Flex>
+        <StockArticles viewingStockSymbol={viewingStockSymbol} />
+      </Flex>
       <PurchaseStock viewingStockSymbol={viewingStockSymbol} />
       <PriceGraph viewingStockSymbol={viewingStockSymbol} />
     </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/StockArticles.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/StockArticles.module.scss
@@ -1,0 +1,38 @@
+@use "@/styles/variables.scss" as vars;
+
+.articlesContainer {
+    background: vars.$white;
+    border-radius: 3px;
+    border: 1px solid vars.$muted-font;
+}
+
+.impactContainer {
+    border: 1px solid vars.$black;
+    border-radius: 3px;
+}
+
+.two {
+    background: vars.$green;
+    color: vars.$white;
+}
+
+.one {
+    background: rgba(vars.$green, 0.25);
+}
+
+.minusTwo {
+    background: vars.$red;
+    color: vars.$white;
+}
+
+.minusOne {
+    background: rgba(vars.$red, 0.25);
+}
+
+.changeArticle {
+    cursor: pointer;
+    
+    &:hover {
+        background: rgba(vars.$muted-font, 0.75);
+    }
+}

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/StockArticles.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/StockArticles.tsx
@@ -1,0 +1,120 @@
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  DoubleArrowDownIcon,
+  DoubleArrowUpIcon,
+  MinusIcon
+} from "@radix-ui/react-icons";
+import { Flex, Text } from "../../../components";
+import { useGameStateSelector } from "../../store/theStockTimesRedux";
+import styles from "./StockArticles.module.scss";
+import clsx from "clsx";
+import { useState } from "react";
+
+export const StockArticles = ({
+  disableChangingArticle,
+  viewingStockSymbol
+}: {
+  disableChangingArticle?: boolean;
+  viewingStockSymbol: string;
+}) => {
+  const articles = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.newsArticles.articles
+  );
+  const articlesOnStock = articles?.[viewingStockSymbol];
+
+  const [viewingArticle, setViewingArticle] = useState(0);
+
+  if (articlesOnStock === undefined || articlesOnStock.length === 0) {
+    return;
+  }
+
+  const requestedArticle = articlesOnStock[viewingArticle];
+  if (requestedArticle === undefined) {
+    return;
+  }
+
+  const renderImpact = () => {
+    if (requestedArticle.impact === 0) {
+      return <MinusIcon />;
+    }
+
+    if (requestedArticle.impact === 1) {
+      return <ChevronUpIcon />;
+    }
+
+    if (requestedArticle.impact === 2) {
+      return <DoubleArrowUpIcon />;
+    }
+
+    if (requestedArticle.impact === -1) {
+      return <ChevronDownIcon />;
+    }
+
+    if (requestedArticle.impact === -2) {
+      return <DoubleArrowDownIcon />;
+    }
+  };
+
+  return (
+    <Flex flex="1" gap="2">
+      {!disableChangingArticle && viewingArticle > 0 && (
+        <Flex
+          className={styles.changeArticle}
+          onClick={() => setViewingArticle(viewingArticle - 1)}
+          px="2"
+        >
+          <Flex align="center">
+            <ArrowLeftIcon />
+          </Flex>
+        </Flex>
+      )}
+      <Flex
+        align="center"
+        className={styles.articlesContainer}
+        flex="1"
+        gap="4"
+        p="3"
+      >
+        <Flex
+          align="center"
+          className={clsx(styles.impactContainer, {
+            [styles.one ?? ""]: requestedArticle.impact === 1,
+            [styles.two ?? ""]: requestedArticle.impact === 2,
+            [styles.minusOne ?? ""]: requestedArticle.impact === -1,
+            [styles.minusTwo ?? ""]: requestedArticle.impact === -2
+          })}
+          justify="center"
+          p="2"
+        >
+          {renderImpact()}
+        </Flex>
+        <Flex direction="column" flex="1">
+          <Flex justify="between">
+            <Text size="4" weight="bold">
+              {requestedArticle.title}
+            </Text>
+            <Text>Day {requestedArticle.addedOn}</Text>
+          </Flex>
+          <Flex>
+            <Text color="gray">{requestedArticle.description}</Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      {!disableChangingArticle &&
+        viewingArticle < articlesOnStock.length - 1 && (
+          <Flex
+            className={styles.changeArticle}
+            onClick={() => setViewingArticle(viewingArticle + 1)}
+            px="2"
+          >
+            <Flex align="center">
+              <ArrowRightIcon />
+            </Flex>
+          </Flex>
+        )}
+    </Flex>
+  );
+};

--- a/packages/games/src/shared/theStockTimes/cycleTime.ts
+++ b/packages/games/src/shared/theStockTimes/cycleTime.ts
@@ -17,7 +17,8 @@ export function cycleTime(cycle: StockTimesCycle): CycleTime {
   const day = Math.floor(currentTime / totalTimePerDay) + 1;
   const time = currentTime % totalTimePerDay;
   const timeFraction = time / totalTimePerDay;
-  const currentCycle: "day" | "night" = time < cycle.dayTime ? "day" : "night";
+  const currentCycle: "day" | "night" =
+    time < cycle.nightTime ? "night" : "day";
 
   return {
     currentCycle,


### PR DESCRIPTION
<img width="1104" alt="Screenshot 2024-12-27 at 10 23 13 PM" src="https://github.com/user-attachments/assets/4e703561-4e5e-4719-a8d6-e13b5e12e090" />
<img width="1088" alt="Screenshot 2024-12-27 at 10 23 17 PM" src="https://github.com/user-attachments/assets/804a6e78-9705-4148-b285-208cd611fc5d" />

This pull request includes several changes to both the backend and frontend of the `theStockTimes` game. The most significant changes involve updating game state handling, adding new features for displaying stock articles, and fixing the cycle time calculation.

### Backend Changes:
* [`packages/backend/src/gameState/ticker/gameStateTicker.service.ts`](diffhunk://#diff-8ffc64c4e36c7a72cb0819a1d7bbf572cd7a0eb3b6a4a8122b45c9ece7968703L61-L68): Removed logging of `didAcceptChange` after updating the game state.
* `packages/games/src/backend/theStockTimes/theStockTimes.ts`: 
  - Added `NEWS_ARTICLES` import and extended `StockTimesNewsArticle` with `WithTimestamp`. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R14) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L63-R64)
  - Updated `TheStockTimesServer` to include timestamps for `lastUpdatedAt` in various places and ensured news articles are added for each stock. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L102-R104) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L141-R155) [[3]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L181-R220)

### Frontend Changes:
* [`packages/games/src/frontend/theStockTimes/components/AvailableStocks.tsx`](diffhunk://#diff-3a57a59b6ffcf01dccf1dc5d5f00cacbc7a555a498724f7ae5f13a4249d2a819R10): Integrated `StockArticles` component to display articles for each stock. [[1]](diffhunk://#diff-3a57a59b6ffcf01dccf1dc5d5f00cacbc7a555a498724f7ae5f13a4249d2a819R10) [[2]](diffhunk://#diff-3a57a59b6ffcf01dccf1dc5d5f00cacbc7a555a498724f7ae5f13a4249d2a819R63-R68)
* [`packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx`](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL40-R40): Fixed cycle time calculation to correctly display "Day" or "Night". [[1]](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL40-R40) [[2]](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL54-R54)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx`](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR5): Added `StockArticles` component to the `SingleStock` view. [[1]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR5) [[2]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR28-R30)

### New Components and Styles:
* [`packages/games/src/frontend/theStockTimes/components/singleStock/StockArticles.tsx`](diffhunk://#diff-4719e524088f4e0cfbffcd455f33829bcfdce2accacbf93c1975bb471baf5e97R1-R120): Created a new component to display stock articles with navigation and impact indicators.
* [`packages/games/src/frontend/theStockTimes/components/singleStock/StockArticles.module.scss`](diffhunk://#diff-3da4d30d784d5d1825ad8b8e62319de4864ac85d4067ab988adb443118c1ea9fR1-R38): Added styles for the new `StockArticles` component.

### Shared Changes:
* [`packages/games/src/shared/theStockTimes/cycleTime.ts`](diffhunk://#diff-ca59685e2fbd545a52e2b85e36264782b6e8e59d4c45af8c5dc0b328fbbdcacdL20-R21): Corrected the calculation of `currentCycle` to switch between "day" and "night" based on `nightTime`.
