### PR TITLE
Start pricing based on the news articles

### DIFF
--- a/packages/games/src/backend/theStockTimes/stocks/availableStocks.ts
+++ b/packages/games/src/backend/theStockTimes/stocks/availableStocks.ts
@@ -401,7 +401,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.0037
+        price: 3.37
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -414,7 +414,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.48
+        price: 1.48
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -440,7 +440,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.00021
+        price: 6.21
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -453,7 +453,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.75
+        price: 5.75
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -466,7 +466,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.0089
+        price: 10.89
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -479,7 +479,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.0015
+        price: 1.15
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -492,7 +492,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.0042
+        price: 3.42
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -505,7 +505,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.0023
+        price: 5.23
       }
     ],
     lastUpdatedAt: new Date().toISOString(),
@@ -518,7 +518,7 @@ export const AVAILABLE_STOCKS: StockWithSymbol[] = [
     history: [
       {
         lastUpdatedAt: "2024-11-30T10:00:00Z",
-        price: 0.0067
+        price: 2.67
       }
     ],
     lastUpdatedAt: new Date().toISOString(),

--- a/packages/games/src/frontend/theStockTimes/theStockTimesConfiguration.ts
+++ b/packages/games/src/frontend/theStockTimes/theStockTimesConfiguration.ts
@@ -4,10 +4,10 @@ import { MapGameConfiguration } from "../baseConfiguration";
 export const TheStockTimesConfiguration: MapGameConfiguration<TheStockTimesGameConfiguration> =
   {
     startingCash: {
-      default: 100_000,
+      default: 10_000,
       label: "Starting cash",
-      max: 1_000_000,
-      min: 1_000,
+      max: 100_000,
+      min: 100,
       required: true,
       type: "number"
     },


### PR DESCRIPTION
Takes into account the latest news article when pricing the stock. It does this by using the impact to decide the probability of the price increasing, and percent of the previous price the next price is maximally allowed to change by. A rough approximation to make for an exciting growth curve.

---

This pull request includes significant changes to the stock price calculations and game configuration for "The Stock Times". The most important changes involve updating stock prices, incorporating news articles into stock price calculations, and modifying game configuration values.

### Stock Price Updates:
* Updated the historical prices of various stocks in `AVAILABLE_STOCKS` to more realistic values. [[1]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L404-R404) [[2]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L417-R417) [[3]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L443-R443) [[4]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L456-R456) [[5]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L469-R469) [[6]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L482-R482) [[7]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L495-R495) [[8]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L508-R508) [[9]](diffhunk://#diff-a45d565207b45ff8f2b32e91e1f575f4cc86cdee58af2d86b9b5d7da9d7909e4L521-R521)

### Game Logic Enhancements:
* Modified the `TheStockTimesServer` class to include the latest news articles when calculating stock prices, which affects the probability of price increases and the percentage change in prices. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R172) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R230) [[3]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L246-R262)
* Added a new method `accountForNewsArticle` to handle the impact of news articles on stock prices.

### Game Configuration Changes:
* Adjusted the default and range values for the starting cash in `TheStockTimesConfiguration`.

### Code Reorganization:
* Reorganized import statements in `theStockTimes.ts` for better readability and maintainability.

### Cycle Timing Adjustments:
* Updated the day time duration and added an `endDay` parameter to the game cycle configuration.