### PR TITLE
Move the articles to their own and make the clock more prominent

### DIFF
--- a/packages/games/src/frontend/theStockTimes/TheStockTimes.module.scss
+++ b/packages/games/src/frontend/theStockTimes/TheStockTimes.module.scss
@@ -6,6 +6,23 @@
 
 .gameName {
     position: fixed;
-    top: 10px;
-    right: 10px;
+    top: 5px;
+    right: 5px;
+}
+
+.background {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: -1;
+    
+    &.night {
+        background: rgba(vars.$blue, 0.1);
+    }
+
+    &.day {
+        background: rgba(vars.$yellow, 0.1);
+    }
 }

--- a/packages/games/src/frontend/theStockTimes/components/AvailableStocks.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/AvailableStocks.tsx
@@ -1,13 +1,12 @@
+import { Flex, Text } from "../../components";
 import {
   updateTheStockTimesLocalState,
   useGameStateDispatch,
   useGameStateSelector
 } from "../store/theStockTimesRedux";
-import { Flex, Text } from "../../components";
-import styles from "./AvailableStocks.module.scss";
 import { displayDollar } from "../utils/displayDollar";
+import styles from "./AvailableStocks.module.scss";
 import { SingleStock } from "./singleStock/SingleStock";
-import { StockArticles } from "./singleStock/StockArticles";
 
 export const AvailableStocks = () => {
   const dispatch = useGameStateDispatch();
@@ -60,12 +59,6 @@ export const AvailableStocks = () => {
             <Text color="gray" mt="2" size="2">
               {stock.description}
             </Text>
-            <Flex flex="1" mt="2">
-              <StockArticles
-                disableChangingArticle={true}
-                viewingStockSymbol={stockSymbol}
-              />
-            </Flex>
           </Flex>
         );
       })}

--- a/packages/games/src/frontend/theStockTimes/components/DayArticles.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/DayArticles.module.scss
@@ -1,0 +1,38 @@
+@use "@/styles/variables.scss" as vars;
+
+.articlesContainer {
+    background: vars.$white;
+    border-radius: 3px;
+    border: 1px solid vars.$muted-font;
+}
+
+.impactContainer {
+    border: 1px solid vars.$black;
+    border-radius: 3px;
+}
+
+.two {
+    background: vars.$green;
+    color: vars.$white;
+}
+
+.one {
+    background: rgba(vars.$green, 0.25);
+}
+
+.minusTwo {
+    background: vars.$red;
+    color: vars.$white;
+}
+
+.minusOne {
+    background: rgba(vars.$red, 0.25);
+}
+
+.changeArticle {
+    cursor: pointer;
+    
+    &:hover {
+        background: rgba(vars.$muted-font, 0.75);
+    }
+}

--- a/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
@@ -1,0 +1,94 @@
+import { useMemo, useState } from "react";
+import { useGameStateSelector } from "../store/theStockTimesRedux";
+import { shuffle } from "lodash-es";
+import { StockArticle } from "../../../backend/theStockTimes/theStockTimes";
+import { Button, Flex, Text } from "../../components";
+import styles from "./DayArticles.module.scss";
+import { ArrowLeftIcon, ArrowRightIcon } from "@radix-ui/react-icons";
+
+export const DayArticles = () => {
+  const articles = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.newsArticles.articles
+  );
+
+  const [selectedDay, setSelectedDay] = useState(0);
+
+  const viewingArticles: StockArticle[] = useMemo(() => {
+    const collapsedArticles = Object.keys(articles ?? {}).map(
+      (stockSymbol) => articles?.[stockSymbol]?.[selectedDay]
+    );
+    const filteredArticles = collapsedArticles.filter(
+      (article) => article !== undefined && article?.title !== "No news"
+    ) as StockArticle[];
+
+    if (filteredArticles.length === 0) {
+      return [
+        collapsedArticles[0] ??
+          ({
+            addedOn: 0,
+            description: "No news",
+            impact: 0,
+            lastUpdatedAt: new Date().toISOString(),
+            title: "No news"
+          } as StockArticle)
+      ];
+    }
+
+    return shuffle(filteredArticles);
+  }, [articles, selectedDay]);
+
+  return (
+    <Flex
+      className={styles.articlesContainer}
+      direction="column"
+      flex="1"
+      gap="3"
+      p="3"
+    >
+      <Flex justify="between">
+        <Flex>
+          <Button
+            disabled={selectedDay === 0}
+            onClick={() => setSelectedDay(selectedDay - 1)}
+          >
+            <ArrowLeftIcon />
+          </Button>
+        </Flex>
+        <Text size="4">Day {viewingArticles[0]?.addedOn} news</Text>
+        <Flex gap="3" justify="end">
+          {selectedDay !== 0 && (
+            <Button color="red" onClick={() => setSelectedDay(0)}>
+              Today
+            </Button>
+          )}
+          <Button
+            disabled={viewingArticles[0]?.addedOn === 0}
+            onClick={() => setSelectedDay(selectedDay + 1)}
+          >
+            <ArrowRightIcon />
+          </Button>
+        </Flex>
+      </Flex>
+      <Flex direction="column" gap="2">
+        {viewingArticles.map((article) => (
+          <Flex
+            className={styles.articlesContainer}
+            direction="column"
+            flex="1"
+            key={article.title}
+            p="3"
+          >
+            <Flex justify="between">
+              <Text size="4" weight="bold">
+                {article.title}
+              </Text>
+            </Flex>
+            <Flex>
+              <Text color="gray">{article.description}</Text>
+            </Flex>
+          </Flex>
+        ))}
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
@@ -1,7 +1,7 @@
 @use "@/styles/variables.scss" as vars;
 
 .baseClock {
-    fill: vars.$white;
+    fill: vars.$yellow;
     stroke: vars.$black;
     stroke-width: 1;
 }
@@ -14,6 +14,6 @@
 
 .pointer {
     stroke: vars.$black;
-    stroke-width: 3;
+    stroke-width: 5;
     stroke-linecap: round;
 }

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
@@ -1,16 +1,17 @@
-import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { CycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 import { StockTimesCycle } from "../../../../backend/theStockTimes/theStockTimes";
-import { Flex, Text } from "../../../components";
+import { Flex } from "../../../components";
 import styles from "./Clock.module.scss";
-import { useEffect, useState } from "react";
+
+const size = 75;
+
+const radius = size / 2 - 1;
+const centerX = size / 2;
+const centerY = size / 2;
 
 function calculateNightTimeArc(cycle: StockTimesCycle) {
   const percentNight = cycle.nightTime / (cycle.dayTime + cycle.nightTime);
   const angle = percentNight * 360;
-
-  const radius = 20;
-  const centerX = 25;
-  const centerY = 25;
 
   const endX = centerX + radius * Math.cos((angle - 90) * (Math.PI / 180));
   const endY = centerY + radius * Math.sin((angle - 90) * (Math.PI / 180));
@@ -26,40 +27,47 @@ function calculateNightTimeArc(cycle: StockTimesCycle) {
 function calculateClockPointer(timeFraction: number) {
   const angle = timeFraction * 360;
 
-  const radius = 18;
-  const centerX = 25;
-  const centerY = 25;
-
-  const endX = centerX + radius * Math.cos((angle - 90) * (Math.PI / 180));
-  const endY = centerY + radius * Math.sin((angle - 90) * (Math.PI / 180));
+  const endX =
+    centerX + radius * Math.cos((angle - 90) * (Math.PI / 180)) * 0.95;
+  const endY =
+    centerY + radius * Math.sin((angle - 90) * (Math.PI / 180)) * 0.95;
 
   return `M ${centerX} ${centerY} L ${endX} ${endY}`;
 }
 
-export const Clock = ({ cycle }: { cycle: StockTimesCycle }) => {
-  const { currentCycle, day, timeFraction } = cycleTime(cycle);
-
-  const [_, setCounter] = useState(0);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setCounter((prev) => prev + 1);
-    }, 100);
-
-    return () => clearInterval(interval);
-  }, []);
+export const Clock = ({
+  calculatedCycleTime,
+  cycle
+}: {
+  calculatedCycleTime: CycleTime;
+  cycle: StockTimesCycle;
+}) => {
+  const { day, timeFraction } = calculatedCycleTime;
 
   return (
     <Flex align="center" gap="1">
-      <Text size="2">{currentCycle === "day" ? "Day" : "Night"}</Text>
-      <Text size="2">{day}</Text>
-      <svg height={50} width={50}>
-        <circle className={styles.baseClock} cx="25" cy="25" r="20" />
+      <svg height={size} width={size}>
+        <circle
+          className={styles.baseClock}
+          cx={centerX}
+          cy={centerY}
+          r={radius}
+        />
         <path className={styles.night} d={calculateNightTimeArc(cycle)} />
         <path
           className={styles.pointer}
           d={calculateClockPointer(timeFraction)}
         />
+        <circle
+          cx={centerX}
+          cy={centerY}
+          fill="white"
+          r={radius * 0.5}
+          stroke="black"
+        />
+        <text dy=".3em" textAnchor="middle" x={centerX} y={centerY}>
+          {day}
+        </text>
       </svg>
     </Flex>
   );

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx
@@ -2,7 +2,6 @@ import { Flex } from "../../../components";
 import { useGameStateSelector } from "../../store/theStockTimesRedux";
 import { PriceGraph } from "./PriceGraph";
 import { PurchaseStock } from "./PurchaseStock";
-import { StockArticles } from "./StockArticles";
 import { StockDetails } from "./StockDetails";
 
 export const SingleStock = ({
@@ -25,9 +24,6 @@ export const SingleStock = ({
         thisStock={thisStock}
         viewingStockSymbol={viewingStockSymbol}
       />
-      <Flex>
-        <StockArticles viewingStockSymbol={viewingStockSymbol} />
-      </Flex>
       <PurchaseStock viewingStockSymbol={viewingStockSymbol} />
       <PriceGraph viewingStockSymbol={viewingStockSymbol} />
     </Flex>

--- a/packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts
@@ -1,0 +1,29 @@
+import {
+  CycleTime,
+  cycleTime
+} from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { StockTimesCycle } from "../../../backend/theStockTimes/theStockTimes";
+import { useEffect, useState } from "react";
+
+export function useCycleTime(cycle: StockTimesCycle | undefined): CycleTime {
+  const [_, setCounter] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCounter((prev) => prev + 1);
+    }, 100);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (cycle === undefined) {
+    return {
+      currentCycle: "day",
+      day: 0,
+      time: 0,
+      timeFraction: 0
+    };
+  }
+
+  return cycleTime(cycle);
+}

--- a/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
@@ -1,12 +1,17 @@
+import clsx from "clsx";
 import { Flex } from "../components";
 import { AvailableStocks } from "./components/AvailableStocks";
 import { Clock } from "./components/cycle/Clock";
+import { DayArticles } from "./components/DayArticles";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
+import { useCycleTime } from "./hooks/cycleTime";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 import styles from "./TheStockTimes.module.scss";
 
 export const DisplayTheStockTimes = () => {
   const gameState = useGameStateSelector((s) => s.gameStateSlice.gameState);
+
+  const calculatedCycleTime = useCycleTime(gameState?.cycle);
 
   if (gameState === undefined) {
     return;
@@ -14,13 +19,25 @@ export const DisplayTheStockTimes = () => {
 
   return (
     <Flex className={styles.mainContainer} flex="1">
+      <Flex
+        className={clsx(styles.background, {
+          [styles.day ?? ""]: calculatedCycleTime.currentCycle === "day",
+          [styles.night ?? ""]: calculatedCycleTime.currentCycle === "night"
+        })}
+      />
       <Flex align="center" className={styles.gameName} gap="2">
-        <Clock cycle={gameState.cycle} />
+        <Clock
+          calculatedCycleTime={calculatedCycleTime}
+          cycle={gameState.cycle}
+        />
       </Flex>
       <Flex flex="1">
         <PlayerPortfolio />
       </Flex>
-      <Flex flex="2">
+      <Flex flex="1" ml="2">
+        <DayArticles />
+      </Flex>
+      <Flex flex="2" mr="5">
         <AvailableStocks />
       </Flex>
     </Flex>


### PR DESCRIPTION
<img width="1728" alt="Screenshot 2024-12-28 at 11 30 01 AM" src="https://github.com/user-attachments/assets/0f7457f0-a7a9-486d-8163-2fdff3f3f80b" />

This pull request includes several changes to the `TheStockTimes` game frontend, focusing on UI improvements, component updates, and code simplifications. The most important changes are summarized below.

### UI Improvements:

* [`packages/games/src/frontend/theStockTimes/TheStockTimes.module.scss`](diffhunk://#diff-823c2d8d19109ec7dc8422d560ad0150648b2b6d7b3c1d6b82e1064d8908e9e4L9-R27): Adjusted the position of `.gameName` and added a new `.background` class with `day` and `night` variants.
* [`packages/games/src/frontend/theStockTimes/components/DayArticles.module.scss`](diffhunk://#diff-e81d89b8816885fb2ccb14dabdc0654690470ba18a2951dccc7296a41e826ac9R1-R38): Added styles for `.articlesContainer`, `.impactContainer`, and article impact classes.
* [`packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss`](diffhunk://#diff-9cfc6c9c857efbebfb96a9d2d3977beb93522b46264fc148bdeffa519a12ed0bL4-R4): Changed `.baseClock` fill color and increased `.pointer` stroke width. [[1]](diffhunk://#diff-9cfc6c9c857efbebfb96a9d2d3977beb93522b46264fc148bdeffa519a12ed0bL4-R4) [[2]](diffhunk://#diff-9cfc6c9c857efbebfb96a9d2d3977beb93522b46264fc148bdeffa519a12ed0bL17-R17)

### Component Updates:

* [`packages/games/src/frontend/theStockTimes/components/DayArticles.tsx`](diffhunk://#diff-d86e52bb154f0c7ea2bc77d690a112db9d75005ba4c053b27c180a5b5c10934cR1-R94): Introduced a new `DayArticles` component to display news articles with navigation buttons.
* [`packages/games/src/frontend/theStockTimes/components/Clock.tsx`](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL1-L14): Refactored the `Clock` component to use `calculatedCycleTime` and added a center circle with day text. [[1]](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL1-L14) [[2]](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL29-R70)

### Code Simplifications:

* [`packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts`](diffhunk://#diff-a436cacb67888a9aa5a38e2ebafe0e3364a53464a73b99fe9114ca78a98883b6R1-R29): Added a `useCycleTime` hook to manage cycle time state and interval updates.
* [`packages/games/src/frontend/theStockTimes/theStockTimes.tsx`](diffhunk://#diff-24580a30d72b6158eb4069bf61cdc2ab7aa4d7e38b3ede36ad8655dbcd0db8b3R1-R40): Updated `DisplayTheStockTimes` to use `useCycleTime` and included the new `DayArticles` component.

### Code Cleanup:

* [`packages/games/src/frontend/theStockTimes/components/AvailableStocks.tsx`](diffhunk://#diff-3a57a59b6ffcf01dccf1dc5d5f00cacbc7a555a498724f7ae5f13a4249d2a819R1-L10): Reorganized imports and removed the `StockArticles` component. [[1]](diffhunk://#diff-3a57a59b6ffcf01dccf1dc5d5f00cacbc7a555a498724f7ae5f13a4249d2a819R1-L10) [[2]](diffhunk://#diff-3a57a59b6ffcf01dccf1dc5d5f00cacbc7a555a498724f7ae5f13a4249d2a819L63-L68)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx`](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfL5): Removed the `StockArticles` component from `SingleStock`. [[1]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfL5) [[2]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfL28-L30)