### PR TITLE
Add final scoreboard

### DIFF
--- a/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.module.scss
@@ -1,0 +1,18 @@
+@use "@/styles/variables.scss" as vars;
+
+.teamContainer {
+    border-radius: 3px;
+    background: vars.$white;
+    border: 1px solid vars.$black;
+}
+
+.divider {
+    height: 1px;
+    background: vars.$black;
+    width: 200px;
+}
+
+.gold {
+    background: vars.$yellow;
+    color: vars.$white;
+}

--- a/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
@@ -1,0 +1,34 @@
+import clsx from "clsx";
+import { Flex, Text } from "../../components";
+import { selectTotalTeamValue } from "../store/selectors";
+import { useGameStateSelector } from "../store/theStockTimesRedux";
+import { displayDollar } from "../utils/displayDollar";
+import styles from "./FinalScoreboard.module.scss";
+
+export const FinalScoreboard = () => {
+  const teams = useGameStateSelector(selectTotalTeamValue);
+
+  return (
+    <Flex align="center" direction="column" flex="1" gap="3" justify="center">
+      {teams.map((team, index) => (
+        <Flex
+          className={clsx(styles.teamContainer, {
+            [styles.gold ?? ""]: index === 0
+          })}
+          direction="column"
+          gap="2"
+          key={team.teamName}
+          p="3"
+        >
+          <Flex align="center" gap="2">
+            <Text size="8">{index + 1})</Text>
+            <Text size="8">{team.teamName}</Text>
+            <Flex className={styles.divider} mx="2" />
+            <Text size="8">{displayDollar(team.totalValue)}</Text>
+          </Flex>
+          <Flex>{team.players?.map((p) => p.displayName).join(", ")}</Flex>
+        </Flex>
+      ))}
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/theStockTimes.tsx
@@ -7,11 +7,17 @@ import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import { useCycleTime } from "./hooks/cycleTime";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 import styles from "./TheStockTimes.module.scss";
+import { FinalScoreboard } from "./components/FinalScoreboard";
 
 export const DisplayTheStockTimes = () => {
+  const gameInfo = useGameStateSelector((s) => s.gameStateSlice.gameInfo);
   const gameState = useGameStateSelector((s) => s.gameStateSlice.gameState);
 
   const calculatedCycleTime = useCycleTime(gameState?.cycle);
+
+  if (gameInfo?.currentGameState === "finished") {
+    return <FinalScoreboard />;
+  }
 
   if (gameState === undefined) {
     return;


### PR DESCRIPTION
<img width="702" alt="Screenshot 2024-12-28 at 12 23 01 PM" src="https://github.com/user-attachments/assets/0650092a-d0ba-409e-9546-f4edb1bbc3c2" />

This pull request introduces new functionality to display the final scoreboard in the Stock Times game. The changes include adding new styles, creating a new scoreboard component, and updating the state selectors to calculate the total team value.

Key changes:

### New Styles:
* [`FinalScoreboard.module.scss`](diffhunk://#diff-040e174b98b04b12b7502e84329e399b84fa2800e4fd240a12e2c65c0e72a68aR1-R18): Added styles for the team container, divider, and gold background using SCSS variables.

### New Component:
* [`FinalScoreboard.tsx`](diffhunk://#diff-f2bb0f2c95ad68730044318df7d89d24de7d461d429283dcafe0402341b62d9cR1-R34): Created a new `FinalScoreboard` component that uses the new styles and displays the final scores of the teams.

### State Selector:
* [`selectors.ts`](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0R52-R96): Added a new selector `selectTotalTeamValue` to compute the total value of each team based on their players and stocks.

### Integration:
* [`theStockTimes.tsx`](diffhunk://#diff-24580a30d72b6158eb4069bf61cdc2ab7aa4d7e38b3ede36ad8655dbcd0db8b3R10-R21): Integrated the `FinalScoreboard` component to display when the game state is finished.