### PR TITLE
Implement global screen for stock times

### DIFF
--- a/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
+++ b/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
@@ -1,14 +1,26 @@
 import { Flex } from "../components";
+import { Clock } from "./components/cycle/Clock";
+import { FinalScoreboard } from "./components/FinalScoreboard";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 
 export const StockTimesGlobalScreen = () => {
   const gameInfo = useGameStateSelector((s) => s.gameStateSlice.gameInfo);
   const gameState = useGameStateSelector((s) => s.gameStateSlice.gameState);
 
+  if (gameState === undefined) {
+    return;
+  }
+
   return (
-    <Flex>
-      {JSON.stringify(gameInfo, null, 2)}
-      {JSON.stringify(gameState, null, 2)}
+    <Flex gap="2">
+      <Flex flex="1">
+        <FinalScoreboard />
+      </Flex>
+      {gameInfo?.currentGameState === "playing" && (
+        <Flex flex="1">
+          <Clock cycle={gameState?.cycle} size={window.innerWidth / 2} />
+        </Flex>
+      )}
     </Flex>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
@@ -14,8 +14,8 @@
 
 .pointer {
     stroke: vars.$black;
-    stroke-width: 5;
     stroke-linecap: round;
+    transition: all 300ms ease-out;
 }
 
 .lastDay {

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
@@ -4,63 +4,84 @@ import { Flex } from "../../../components";
 import { useCycleTime } from "../../hooks/cycleTime";
 import styles from "./Clock.module.scss";
 
-const size = 75;
+const DEFAULT_SIZE = 75;
 
-const radius = size / 2 - 1;
-const centerX = size / 2;
-const centerY = size / 2;
+const radius = (size: number) => size / 2 - 1;
+const centerX = (size: number) => size / 2;
+const centerY = (size: number) => size / 2;
 
-function calculateNightTimeArc(cycle: StockTimesCycle) {
+function calculateNightTimeArc(cycle: StockTimesCycle, size: number) {
   const percentNight = cycle.nightTime / (cycle.dayTime + cycle.nightTime);
   const angle = percentNight * 360;
 
-  const endX = centerX + radius * Math.cos((angle - 90) * (Math.PI / 180));
-  const endY = centerY + radius * Math.sin((angle - 90) * (Math.PI / 180));
+  const endX =
+    centerX(size) + radius(size) * Math.cos((angle - 90) * (Math.PI / 180));
+  const endY =
+    centerY(size) + radius(size) * Math.sin((angle - 90) * (Math.PI / 180));
 
   const largeArcFlag = angle > 180 ? 1 : 0;
 
-  return `M ${centerX} ${centerY}
-             L ${centerX} ${centerY - radius}
-             A ${radius} ${radius} 0 ${largeArcFlag} 1 ${endX} ${endY}
+  return `M ${centerX(size)} ${centerY(size)}
+             L ${centerX(size)} ${centerY(size) - radius(size)}
+             A ${radius(size)} ${radius(size)} 0 ${largeArcFlag} 1 ${endX} ${endY}
              Z`;
 }
 
-function calculateClockPointer(timeFraction: number) {
+function calculateClockPointer(timeFraction: number, size: number) {
   const angle = timeFraction * 360;
 
   const endX =
-    centerX + radius * Math.cos((angle - 90) * (Math.PI / 180)) * 0.95;
+    centerX(size) +
+    radius(size) * Math.cos((angle - 90) * (Math.PI / 180)) * 0.95;
   const endY =
-    centerY + radius * Math.sin((angle - 90) * (Math.PI / 180)) * 0.95;
+    centerY(size) +
+    radius(size) * Math.sin((angle - 90) * (Math.PI / 180)) * 0.95;
 
-  return `M ${centerX} ${centerY} L ${endX} ${endY}`;
+  return `M ${centerX(size)} ${centerY(size)} L ${endX} ${endY}`;
 }
 
-export const Clock = ({ cycle }: { cycle: StockTimesCycle }) => {
+export const Clock = ({
+  cycle,
+  size
+}: {
+  cycle: StockTimesCycle;
+  size?: number;
+}) => {
   const calculatedCycleTime = useCycleTime(cycle);
+  const finalSize = size ?? DEFAULT_SIZE;
 
   const { day, timeFraction } = calculatedCycleTime;
 
   return (
     <>
+      <Flex
+        className={clsx(styles.background, {
+          [styles.day ?? ""]: calculatedCycleTime.currentCycle === "day",
+          [styles.night ?? ""]: calculatedCycleTime.currentCycle === "night"
+        })}
+      />
       <Flex align="center" gap="1">
         <svg height={size} width={size}>
           <circle
             className={styles.baseClock}
-            cx={centerX}
-            cy={centerY}
-            r={radius}
+            cx={centerX(finalSize)}
+            cy={centerY(finalSize)}
+            r={radius(finalSize)}
           />
-          <path className={styles.night} d={calculateNightTimeArc(cycle)} />
+          <path
+            className={styles.night}
+            d={calculateNightTimeArc(cycle, finalSize)}
+          />
           <path
             className={styles.pointer}
-            d={calculateClockPointer(timeFraction)}
+            d={calculateClockPointer(timeFraction, finalSize)}
+            strokeWidth={finalSize / 20}
           />
           <circle
-            cx={centerX}
-            cy={centerY}
+            cx={centerX(finalSize)}
+            cy={centerY(finalSize)}
             fill="white"
-            r={radius * 0.5}
+            r={radius(finalSize) * 0.5}
             stroke="black"
           />
           <text
@@ -68,20 +89,15 @@ export const Clock = ({ cycle }: { cycle: StockTimesCycle }) => {
               [styles.lastDay ?? ""]: cycle.endDay - 1 === day
             })}
             dy=".3em"
+            fontSize={finalSize / 5}
             textAnchor="middle"
-            x={centerX}
-            y={centerY}
+            x={centerX(finalSize)}
+            y={centerY(finalSize)}
           >
             {day}
           </text>
         </svg>
       </Flex>
-      <Flex
-        className={clsx(styles.background, {
-          [styles.day ?? ""]: calculatedCycleTime.currentCycle === "day",
-          [styles.night ?? ""]: calculatedCycleTime.currentCycle === "night"
-        })}
-      />
     </>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts
@@ -11,7 +11,7 @@ export function useCycleTime(cycle: StockTimesCycle | undefined): CycleTime {
   useEffect(() => {
     const interval = setInterval(() => {
       setCounter((prev) => prev + 1);
-    }, 100);
+    }, 1000);
 
     return () => clearInterval(interval);
   }, []);


### PR DESCRIPTION
![Screenshot 2024-12-29 at 4 15 21 PM](https://github.com/user-attachments/assets/fd0b765c-8556-45e5-b888-03f1ae46e148)

This pull request includes several changes to the `StockTimesGlobalScreen` and its associated components to improve the game's UI and functionality. The most important changes include adding new components, updating styles, and refactoring the `Clock` component to be more dynamic.

### Component Additions and Updates:

* [`packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx`](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R2-R23): Added `Clock` and `FinalScoreboard` components to the `StockTimesGlobalScreen` and updated the rendering logic to include these components based on the game state.

### Style Improvements:

* [`packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss`](diffhunk://#diff-9cfc6c9c857efbebfb96a9d2d3977beb93522b46264fc148bdeffa519a12ed0bL17-R18): Added a transition effect to the `.pointer` class for smoother animations.

### Refactoring for Dynamic Sizing:

* [`packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx`](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eL7-L84): Refactored the `Clock` component to accept a `size` prop, making it more flexible and dynamic. Updated internal calculations to use the provided size.

### Performance Enhancement:

* [`packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts`](diffhunk://#diff-a436cacb67888a9aa5a38e2ebafe0e3364a53464a73b99fe9114ca78a98883b6L14-R14): Increased the interval duration in the `useCycleTime` hook from 100ms to 1000ms to reduce the frequency of updates and improve performance.