### PR TITLE
Add store and first power (loans)

### DIFF
--- a/packages/frontend/src/components/inGame/GameLobby.tsx
+++ b/packages/frontend/src/components/inGame/GameLobby.tsx
@@ -131,16 +131,19 @@ export const GameLobby = () => {
     }
 
     return (
-      <Flex
-        className={styles.players}
-        gap="3"
-        style={{ background: getTeamColor() }}
-      >
-        {undecided.map((p) => (
-          <Flex justify="center" key={p.playerId}>
-            <Text size="4">{p.displayName}</Text>
-          </Flex>
-        ))}
+      <Flex justify="center">
+        <Flex
+          className={styles.players}
+          gap="3"
+          mx="3"
+          style={{ background: getTeamColor() }}
+        >
+          {undecided.map((p) => (
+            <Flex justify="center" key={p.playerId}>
+              <Text size="4">{p.displayName}</Text>
+            </Flex>
+          ))}
+        </Flex>
       </Flex>
     );
   };

--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -44,10 +44,19 @@ export interface TransactionHistory {
   type: "buy" | "sell";
 }
 
+export interface StorePowerUpUsage {
+  cooldownTime: number | undefined;
+  unlocksAt: string | undefined;
+}
+
 export interface StockTimesPlayer extends WithTimestamp {
   cash: number;
+  debt: number;
   ownedStocks: {
     [stockSymbol: string]: OwnedStock[];
+  };
+  storePowers: {
+    loan: StorePowerUpUsage;
   };
   team: number;
   transactionHistory: TransactionHistory[];
@@ -95,8 +104,8 @@ export class TheStockTimesServer
     return {
       gameState: {
         cycle: {
-          dayTime: 60 * 1_000, // 40 seconds
-          endDay: 16, // 15 full days = 15 minute game
+          dayTime: 60 * 1_000, // 60 seconds
+          endDay: 11, // 10 full days = 13 minute game
           nightTime: 20 * 1_000, // 20 seconds
           startTime: new Date().toISOString()
         },
@@ -128,8 +137,15 @@ export class TheStockTimesServer
     for (const player of game.players) {
       newGameState.players[player.playerId] = {
         cash: game.gameConfiguration.startingCash,
+        debt: 0,
         lastUpdatedAt: new Date().toISOString(),
         ownedStocks: {},
+        storePowers: {
+          loan: {
+            cooldownTime: undefined,
+            unlocksAt: undefined
+          }
+        },
         team: player.team ?? 0,
         transactionHistory: []
       };

--- a/packages/games/src/frontend/components/index.ts
+++ b/packages/games/src/frontend/components/index.ts
@@ -1,2 +1,2 @@
 export * from "@/lib/radix";
-export { Text } from "@radix-ui/themes";
+export { Text, Tabs, Progress } from "@radix-ui/themes";

--- a/packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx
@@ -5,8 +5,8 @@ import { Clock } from "./components/cycle/Clock";
 import { DayArticles } from "./components/DayArticles";
 import { FinalScoreboard } from "./components/FinalScoreboard";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
-import { useGameStateSelector } from "./store/theStockTimesRedux";
 import styles from "./DisplayTheStockTimes.module.scss";
+import { useGameStateSelector } from "./store/theStockTimesRedux";
 
 export const DisplayTheStockTimes = () => {
   const gameInfo = useGameStateSelector((s) => s.gameStateSlice.gameInfo);

--- a/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
@@ -24,7 +24,7 @@ export const FinalScoreboard = () => {
             <Text size="8">{index + 1})</Text>
             <Text size="8">{team.teamName}</Text>
             <Flex className={styles.divider} flex="1" mx="2" />
-            <Text size="8">{displayDollar(team.totalValue)}</Text>
+            <Text size="8">{displayDollar(team.averageTeamValue)}</Text>
           </Flex>
           <Flex>{team.players?.map((p) => p.displayName).join(", ")}</Flex>
         </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.module.scss
@@ -15,3 +15,7 @@
 .cash {
     color: vars.$green;
 }
+
+.debt {
+    color: vars.$red;
+}

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
@@ -1,7 +1,12 @@
-import { Flex, Text } from "../../../components";
-import { selectPlayerPortfolio, selectTeams } from "../../store/selectors";
+import { Flex, Tabs, Text } from "../../../components";
+import {
+  selectPlayerPortfolio,
+  selectTeams,
+  selectTotalTeamValue
+} from "../../store/selectors";
 import { useGameStateSelector } from "../../store/theStockTimesRedux";
 import { displayDollar } from "../../utils/displayDollar";
+import { StockTimesStore } from "../store/StockTimesStore";
 import styles from "./PlayerPortfolio.module.scss";
 import { PlayerStocks } from "./PlayerStocks";
 
@@ -10,7 +15,10 @@ export const PlayerPortfolio = () => {
   const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
 
   const teams = useGameStateSelector(selectTeams);
+  const teamValues = useGameStateSelector(selectTotalTeamValue);
+
   const playerTeam = teams[playerPortfolio?.team ?? 0];
+  const playerTeamValue = teamValues[playerPortfolio?.team ?? 0];
 
   if (playerPortfolio === undefined) {
     return;
@@ -39,6 +47,17 @@ export const PlayerPortfolio = () => {
             </Text>
           </Flex>
         </Flex>
+        <Flex align="center" gap="3">
+          <Flex>
+            <Text>Average team value</Text>
+          </Flex>
+          <Flex className={styles.divider} flex="1" />
+          <Flex>
+            <Text className={styles.cash}>
+              {displayDollar(playerTeamValue?.averageTeamValue)}
+            </Text>
+          </Flex>
+        </Flex>
       </>
     );
   };
@@ -57,6 +76,17 @@ export const PlayerPortfolio = () => {
             </Text>
           </Flex>
         </Flex>
+        <Flex align="center" gap="3">
+          <Flex>
+            <Text>Debt</Text>
+          </Flex>
+          <Flex className={styles.divider} flex="1" />
+          <Flex>
+            <Text className={styles.debt}>
+              {displayDollar(playerPortfolio.debt)}
+            </Text>
+          </Flex>
+        </Flex>
       </>
     );
   };
@@ -70,13 +100,23 @@ export const PlayerPortfolio = () => {
       p="3"
     >
       {renderTeamValue()}
-      <Flex mt="2">
-        <Text color="gray" size="2">
-          Your portfolio
-        </Text>
-      </Flex>
-      {renderYourPortfolio()}
-      <PlayerStocks />
+      <Tabs.Root defaultValue="your-portfolio">
+        <Tabs.List>
+          <Tabs.Trigger value="your-portfolio">Your portfolio</Tabs.Trigger>
+          <Tabs.Trigger value="store">Store</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="your-portfolio">
+          <Flex direction="column" mt="2">
+            {renderYourPortfolio()}
+            <PlayerStocks />
+          </Flex>
+        </Tabs.Content>
+        <Tabs.Content value="store">
+          <Flex direction="column" mt="2">
+            <StockTimesStore />
+          </Flex>
+        </Tabs.Content>
+      </Tabs.Root>
     </Flex>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/components/store/ActivateStorePower.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/ActivateStorePower.tsx
@@ -1,0 +1,23 @@
+import { StockTimesPlayer } from "../../../../backend/theStockTimes/theStockTimes";
+import { Button, Progress } from "../../../components";
+import { useStorePower } from "../../hooks/storePower";
+
+export const ActivateStorePower = ({
+  storePower,
+  onClick
+}: {
+  onClick: () => void;
+  storePower: keyof StockTimesPlayer["storePowers"];
+}) => {
+  const { isAvailable, timeLeft } = useStorePower(storePower);
+
+  if (isAvailable) {
+    return (
+      <Button color="green" onClick={onClick}>
+        Activate
+      </Button>
+    );
+  }
+
+  return <Progress color="blue" value={timeLeft} />;
+};

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.module.scss
@@ -1,0 +1,10 @@
+@use "@/styles/variables.scss" as vars;
+
+.storePower {
+    border-radius: 3px;
+    border: 1px solid vars.$muted-font;
+}
+
+.powerName {
+    border-bottom: 1px solid vars.$muted-font;
+}

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
@@ -1,0 +1,102 @@
+import { Flex, Text } from "../../../components";
+import {
+  selectPlayerPortfolio,
+  selectTotalTeamValue
+} from "../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { displayDollar } from "../../utils/displayDollar";
+import { ActivateStorePower } from "./ActivateStorePower";
+import styles from "./StockTimesStore.module.scss";
+
+const LOAN_AMOUNT = 0.25;
+const LOAN_DEBT = 1.2;
+const LOAN_COOLDOWN = 2.5;
+
+export const StockTimesStore = () => {
+  const dispatch = useGameStateDispatch();
+
+  const { player } = useGameStateSelector((s) => s.playerSlice);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+  const allTeamValues = useGameStateSelector(selectTotalTeamValue);
+
+  const loanAmount =
+    (allTeamValues.reduce(
+      (acc, teamValue) => acc + teamValue.averageTeamValue,
+      0
+    ) /
+      allTeamValues.length) *
+    LOAN_AMOUNT;
+  const loanDebt = loanAmount * LOAN_DEBT;
+
+  const onTakeLoan = () => {
+    if (
+      playerPortfolio === undefined ||
+      player === undefined ||
+      cycle === undefined
+    ) {
+      return;
+    }
+
+    const loanCooldown = (cycle.dayTime + cycle.nightTime) * LOAN_COOLDOWN;
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              cash: playerPortfolio.cash + loanAmount,
+              debt: playerPortfolio.debt + loanDebt,
+              lastUpdatedAt: new Date().toISOString(),
+              storePowers: {
+                ...playerPortfolio.storePowers,
+                loan: {
+                  cooldownTime: loanCooldown,
+                  unlocksAt: new Date(Date.now() + loanCooldown).toISOString()
+                }
+              }
+            }
+          }
+        },
+        player
+      )
+    );
+  };
+
+  return (
+    <Flex direction="column">
+      <Flex className={styles.storePower} direction="column">
+        <Flex align="center" className={styles.powerName} p="2">
+          <Flex flex="1">
+            <Text size="4" weight="bold">
+              Take a loan
+            </Text>
+          </Flex>
+          <Flex flex="1">
+            <ActivateStorePower onClick={onTakeLoan} storePower="loan" />
+          </Flex>
+        </Flex>
+        <Flex direction="column" gap="1" p="2">
+          <Text>
+            <Text color="green">{displayDollar(loanAmount)} cash</Text> for{" "}
+            <Text color="red">{displayDollar(loanDebt)} debt</Text>
+          </Text>
+          <Text color="gray" size="2">
+            Adds cash to your portfolio in exchange for debt. Debt only affects
+            your end score and otherwise has no effect. It cannot be paid off.
+          </Text>
+          <Flex justify="end">
+            <Text color="gray" size="2">
+              2.5 day cooldown
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/hooks/storePower.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/storePower.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { StockTimesPlayer } from "../../../backend/theStockTimes/theStockTimes";
+import { useGameStateSelector } from "../store/theStockTimesRedux";
+import { selectPlayerPortfolio } from "../store/selectors";
+
+export function useStorePower(
+  storePower: keyof StockTimesPlayer["storePowers"]
+) {
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+
+  const [_, setCounter] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCounter((prev) => prev + 1);
+    }, 100);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (playerPortfolio === undefined) {
+    return {
+      isAvailable: false,
+      timeLeft: 0
+    };
+  }
+
+  const accordingStorePower = playerPortfolio.storePowers[storePower];
+
+  const unlocksAt =
+    accordingStorePower.unlocksAt !== undefined
+      ? new Date(accordingStorePower.unlocksAt)
+      : new Date();
+  const isAvailable = new Date().valueOf() >= unlocksAt.valueOf();
+
+  const percentTimeLeft =
+    Math.max(unlocksAt.valueOf() - new Date().valueOf(), 0) /
+    (accordingStorePower.cooldownTime ?? 1);
+
+  return {
+    isAvailable,
+    timeLeft: 100 - percentTimeLeft * 100
+  };
+}

--- a/packages/games/src/frontend/theStockTimes/store/selectors.ts
+++ b/packages/games/src/frontend/theStockTimes/store/selectors.ts
@@ -59,7 +59,7 @@ export const selectTotalTeamValue = createSelector(
   ],
   (players, gamePlayers, stocks, existingTeams) => {
     const teams: {
-      [teamNumber: number]: { totalPlayers: number; totalValue: number };
+      [teamNumber: number]: { averageTeamValue: number; totalPlayers: number };
     } = {};
     for (const player of players ?? []) {
       const accordingPlayer = gamePlayers?.[player.playerId];
@@ -77,11 +77,12 @@ export const selectTotalTeamValue = createSelector(
       }, 0);
 
       teams[player.team ?? 0] = {
-        totalPlayers: (teams[player.team ?? 0]?.totalPlayers ?? 0) + 1,
-        totalValue:
-          (teams[player.team ?? 0]?.totalValue ?? 0) +
-          (accordingPlayer?.cash ?? 0) +
-          heldStockValue
+        averageTeamValue:
+          (teams[player.team ?? 0]?.averageTeamValue ?? 0) +
+          (accordingPlayer?.cash ?? 0) -
+          (accordingPlayer?.debt ?? 0) +
+          heldStockValue,
+        totalPlayers: (teams[player.team ?? 0]?.totalPlayers ?? 0) + 1
       };
     }
 
@@ -91,13 +92,13 @@ export const selectTotalTeamValue = createSelector(
         {
           ...existingTeams[teamNumber],
           ...value,
-          totalValue: value.totalValue / value.totalPlayers
+          averageTeamValue: value.averageTeamValue / value.totalPlayers
         }
       ])
     );
 
     return Object.values(finalTeamValues).sort((a, b) =>
-      a.totalValue > b.totalValue ? -1 : 1
+      a.averageTeamValue > b.averageTeamValue ? -1 : 1
     );
   }
 );

--- a/packages/games/src/frontend/theStockTimes/utils/displayDollar.ts
+++ b/packages/games/src/frontend/theStockTimes/utils/displayDollar.ts
@@ -8,5 +8,5 @@ export function displayDollar(amount: string | number | null | undefined) {
 
   const number =
     typeof amount === "string" ? parseFloat(amount ?? "0") : amount;
-  return `$${number.toLocaleString(undefined, { minimumFractionDigits: 2 })}`;
+  return `$${number.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })}`;
 }


### PR DESCRIPTION
<img width="452" alt="Screenshot 2024-12-30 at 10 24 33 PM" src="https://github.com/user-attachments/assets/7de983ba-3ebb-4199-b16a-593c3fe48b80" />
<img width="431" alt="Screenshot 2024-12-30 at 10 24 30 PM" src="https://github.com/user-attachments/assets/3345fd58-d198-4485-9de8-2e1bc78df965" />
<img width="427" alt="Screenshot 2024-12-30 at 10 24 47 PM" src="https://github.com/user-attachments/assets/0a9fbed3-9501-4b11-8d16-4a5f4c1327ad" />

---

This pull request introduces several changes to the game "The Stock Times" to enhance functionality and improve the user interface. The most important changes include the addition of new store power-up features, updates to the game state and player portfolio, and enhancements to the frontend components.

### Store Power-up Features:
* [`packages/games/src/backend/theStockTimes/theStockTimes.ts`](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R47-R60): Added `StorePowerUpUsage` interface and integrated store powers into `StockTimesPlayer`. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R47-R60) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L98-R108) [[3]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R140-R148)
* [`packages/games/src/frontend/theStockTimes/components/store/ActivateStorePower.tsx`](diffhunk://#diff-75f14508c1fcec37114262c93154d19de37fea05aa54ba51f14c2bbc1af2995bR1-R23): Created `ActivateStorePower` component to handle store power activation.
* [`packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx`](diffhunk://#diff-95b200133c106bea95b10c0b08a4581404ec746fae104af0c64af374b11357c4R1-R102): Implemented `StockTimesStore` component to display and manage store powers, including loan functionality.
* [`packages/games/src/frontend/theStockTimes/hooks/storePower.ts`](diffhunk://#diff-5d171b83e15a09455eebb78b307078b5593f481df798aac58d7754c346191c4aR1-R46): Added `useStorePower` hook to manage store power cooldowns and availability.

### Game State and Player Portfolio:
* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx`](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L1-R9): Updated `PlayerPortfolio` component to display debt and average team value, and integrated a tab system for portfolio and store. [[1]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L1-R9) [[2]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R18-R21) [[3]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R50-R60) [[4]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R79-R89) [[5]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L73-R120)
* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.module.scss`](diffhunk://#diff-b0c36e40f07289cdd090728f077299cc4f9bf0c7350800597542555886ad3abaR18-R21): Added styles for displaying debt in red.

### Frontend Enhancements:
* [`packages/frontend/src/components/inGame/GameLobby.tsx`](diffhunk://#diff-31d84daddfc074dd51f09c47fc412788a35c34773eef9f075f3f47f0f352b12eR134-R138): Improved layout by adding flex containers for better alignment. [[1]](diffhunk://#diff-31d84daddfc074dd51f09c47fc412788a35c34773eef9f075f3f47f0f352b12eR134-R138) [[2]](diffhunk://#diff-31d84daddfc074dd51f09c47fc412788a35c34773eef9f075f3f47f0f352b12eR147)
* [`packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx`](diffhunk://#diff-26112bcd800154b71500a975033d1172c6bca44f776c1f9a42127141cefdf023L8-R9): Fixed import order for better readability.
* [`packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx`](diffhunk://#diff-f2bb0f2c95ad68730044318df7d89d24de7d461d429283dcafe0402341b62d9cL27-R27): Changed display from total value to average team value.
* [`packages/games/src/frontend/theStockTimes/components/index.ts`](diffhunk://#diff-28e0324ebdae10afe0f51baeab708b69d09b9082676d90683f420d7ccedc902dL2-R2): Exported additional components from `@radix-ui/themes`.

### Utility and Selector Updates:
* [`packages/games/src/frontend/theStockTimes/utils/displayDollar.ts`](diffhunk://#diff-e84691df10c3b356d0e3c201e7f543b53ec9d2f710107662a2ba5981ce973586L11-R11): Updated `displayDollar` function to set maximum fraction digits to 2.
* [`packages/games/src/frontend/theStockTimes/store/selectors.ts`](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0L62-R62): Modified `selectTotalTeamValue` selector to calculate and sort by average team value instead of total value. [[1]](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0L62-R62) [[2]](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0L80-R85) [[3]](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0L94-R101)
