### PR TITLE
Add convert losses into gains

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev": "turbo run dev --filter=@resync-games/${0}",
     "docker": "open /Applications/Docker.app && docker-compose -p resync-games -f docker-compose.yml up -d",
     "deploy": "sudo -E docker-compose -p resync-games -f docker-compose.yml up -d",
+    "deploy:restart": "sudo -E docker restart $(sudo -E docker ps -q)",
     "migrate": "turbo run db:migrate --filter=@resync-games/database"
   },
   "monorepo": true,

--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -38,6 +38,7 @@ export interface OwnedStock {
 
 export interface TransactionHistory {
   date: string;
+  lossIntoGain?: boolean;
   price: number;
   quantity: number;
   stockSymbol: string;
@@ -57,6 +58,7 @@ export interface StockTimesPlayer extends WithTimestamp {
   };
   storePowers: {
     loan: StorePowerUpUsage;
+    lossIntoGain: StorePowerUpUsage;
   };
   team: number;
   transactionHistory: TransactionHistory[];
@@ -142,6 +144,10 @@ export class TheStockTimesServer
         ownedStocks: {},
         storePowers: {
           loan: {
+            cooldownTime: undefined,
+            unlocksAt: undefined
+          },
+          lossIntoGain: {
             cooldownTime: undefined,
             unlocksAt: undefined
           }

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
@@ -1,81 +1,13 @@
+import { Flex, Text } from "../../../components";
 import { selectPlayerPortfolio } from "../../store/selectors";
 import {
-  updateTheStockTimesGameState,
   updateTheStockTimesLocalState,
   useGameStateDispatch,
   useGameStateSelector
 } from "../../store/theStockTimesRedux";
-import { Button, Flex, Text } from "../../../components";
 import { displayDollar } from "../../utils/displayDollar";
 import styles from "./PlayerStocks.module.scss";
-import {
-  OwnedStock,
-  TransactionHistory
-} from "../../../../backend/theStockTimes/theStockTimes";
-
-const SellPlayerStock = ({
-  color,
-  currentPrice,
-  ownedStock,
-  symbol
-}: {
-  color: "green" | "red";
-  currentPrice: number;
-  ownedStock: OwnedStock;
-  symbol: string;
-}) => {
-  const dispatch = useGameStateDispatch();
-  const player = useGameStateSelector((s) => s.playerSlice.player);
-  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
-
-  const onSell = () => {
-    if (player === undefined || playerPortfolio === undefined) {
-      return;
-    }
-
-    const newCash = playerPortfolio.cash + currentPrice * ownedStock.quantity;
-    const newOwnedStock = playerPortfolio.ownedStocks[symbol]?.filter(
-      (stock) => stock.date !== ownedStock.date
-    );
-
-    const newTransaction: TransactionHistory = {
-      date: new Date().toISOString(),
-      price: currentPrice,
-      quantity: ownedStock.quantity,
-      stockSymbol: symbol,
-      type: "sell"
-    };
-
-    dispatch(
-      updateTheStockTimesGameState(
-        {
-          players: {
-            [player.playerId]: {
-              ...playerPortfolio,
-              cash: newCash,
-              lastUpdatedAt: new Date().toISOString(),
-              ownedStocks: {
-                ...playerPortfolio.ownedStocks,
-                [symbol]: newOwnedStock
-              },
-              transactionHistory: [
-                ...playerPortfolio.transactionHistory,
-                newTransaction
-              ]
-            }
-          }
-        },
-        player
-      )
-    );
-  };
-
-  return (
-    <Button color={color} onClick={onSell}>
-      Sell
-    </Button>
-  );
-};
+import { SellPlayerStock } from "./SellPlayerStock";
 
 export const PlayerStocks = () => {
   const dispatch = useGameStateDispatch();
@@ -162,7 +94,7 @@ export const PlayerStocks = () => {
                   </Flex>
                   <Flex width="50%">
                     <SellPlayerStock
-                      color={totalProfit >= 0 ? "green" : "red"}
+                      atLoss={totalProfit < 0}
                       currentPrice={currentPrice}
                       ownedStock={ownedStock}
                       symbol={symbol}

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
@@ -1,0 +1,149 @@
+import {
+  OwnedStock,
+  TransactionHistory
+} from "../../../../backend/theStockTimes/theStockTimes";
+import { Button, Flex } from "../../../components";
+import { selectPlayerPortfolio } from "../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { ActivateStorePower } from "../store/ActivateStorePower";
+
+const SELL_INTO_GAIN_COOLDOWN = 1.5;
+
+export const SellPlayerStock = ({
+  atLoss,
+  currentPrice,
+  ownedStock,
+  symbol
+}: {
+  atLoss: boolean;
+  currentPrice: number;
+  ownedStock: OwnedStock;
+  symbol: string;
+}) => {
+  const dispatch = useGameStateDispatch();
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+
+  const onSell = () => {
+    if (player === undefined || playerPortfolio === undefined) {
+      return;
+    }
+
+    const newCash = playerPortfolio.cash + currentPrice * ownedStock.quantity;
+    const newOwnedStock = playerPortfolio.ownedStocks[symbol]?.filter(
+      (stock) => stock.date !== ownedStock.date
+    );
+
+    const newTransaction: TransactionHistory = {
+      date: new Date().toISOString(),
+      price: currentPrice,
+      quantity: ownedStock.quantity,
+      stockSymbol: symbol,
+      type: "sell"
+    };
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              cash: newCash,
+              lastUpdatedAt: new Date().toISOString(),
+              ownedStocks: {
+                ...playerPortfolio.ownedStocks,
+                [symbol]: newOwnedStock
+              },
+              transactionHistory: [
+                ...playerPortfolio.transactionHistory,
+                newTransaction
+              ]
+            }
+          }
+        },
+        player
+      )
+    );
+  };
+
+  const onConvertToGain = () => {
+    if (
+      cycle === undefined ||
+      player === undefined ||
+      playerPortfolio === undefined
+    ) {
+      return;
+    }
+
+    const newPrice = (ownedStock.price - currentPrice) * 2 + currentPrice;
+    const newCash = playerPortfolio.cash + newPrice * ownedStock.quantity;
+    const newOwnedStock = playerPortfolio.ownedStocks[symbol]?.filter(
+      (stock) => stock.date !== ownedStock.date
+    );
+
+    const newTransaction: TransactionHistory = {
+      date: new Date().toISOString(),
+      lossIntoGain: true,
+      price: currentPrice,
+      quantity: ownedStock.quantity,
+      stockSymbol: symbol,
+      type: "sell"
+    };
+
+    const lossIntoGainCooldown =
+      (cycle.dayTime + cycle.nightTime) * SELL_INTO_GAIN_COOLDOWN;
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              cash: newCash,
+              lastUpdatedAt: new Date().toISOString(),
+              ownedStocks: {
+                ...playerPortfolio.ownedStocks,
+                [symbol]: newOwnedStock
+              },
+              storePowers: {
+                ...playerPortfolio.storePowers,
+                lossIntoGain: {
+                  cooldownTime: lossIntoGainCooldown,
+                  unlocksAt: new Date(
+                    Date.now() + lossIntoGainCooldown
+                  ).toISOString()
+                }
+              },
+              transactionHistory: [
+                ...playerPortfolio.transactionHistory,
+                newTransaction
+              ]
+            }
+          }
+        },
+        player
+      )
+    );
+  };
+
+  return (
+    <Flex direction="column" flex="1" gap="2">
+      <Button color={atLoss ? "red" : "green"} onClick={onSell}>
+        Sell
+      </Button>
+      {/* TODO: make this more obvious and clear it up */}
+      {atLoss && (
+        <ActivateStorePower
+          onClick={onConvertToGain}
+          storePower="lossIntoGain"
+          text="Convert to gain"
+        />
+      )}
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/store/ActivateStorePower.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/ActivateStorePower.tsx
@@ -4,17 +4,27 @@ import { useStorePower } from "../../hooks/storePower";
 
 export const ActivateStorePower = ({
   storePower,
+  text,
   onClick
 }: {
-  onClick: () => void;
+  onClick?: () => void;
   storePower: keyof StockTimesPlayer["storePowers"];
+  text?: string;
 }) => {
   const { isAvailable, timeLeft } = useStorePower(storePower);
 
-  if (isAvailable) {
+  if (isAvailable && onClick !== undefined) {
     return (
       <Button color="green" onClick={onClick}>
-        Activate
+        {text ?? "Activate"}
+      </Button>
+    );
+  }
+
+  if (isAvailable) {
+    return (
+      <Button color="green" variant="outline">
+        Available
       </Button>
     );
   }

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
@@ -69,7 +69,7 @@ export const StockTimesStore = () => {
   };
 
   return (
-    <Flex direction="column">
+    <Flex direction="column" gap="2">
       <Flex className={styles.storePower} direction="column">
         <Flex align="center" className={styles.powerName} p="2">
           <Flex flex="1">
@@ -93,6 +93,29 @@ export const StockTimesStore = () => {
           <Flex justify="end">
             <Text color="gray" size="2">
               2.5 day cooldown
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex className={styles.storePower} direction="column">
+        <Flex align="center" className={styles.powerName} p="2">
+          <Flex flex="1">
+            <Text size="4" weight="bold">
+              Losses into gains
+            </Text>
+          </Flex>
+          <Flex flex="1">
+            <ActivateStorePower storePower="lossIntoGain" />
+          </Flex>
+        </Flex>
+        <Flex direction="column" gap="1" p="2">
+          <Text color="gray" size="2">
+            Converts losses into gains for 1 holding. Activate this on a holding
+            with losses in the "your portfolio" section.
+          </Text>
+          <Flex justify="end">
+            <Text color="gray" size="2">
+              1.5 day cooldown
             </Text>
           </Flex>
         </Flex>


### PR DESCRIPTION
![Screenshot 2025-01-03 at 12 03 16 PM](https://github.com/user-attachments/assets/4d57a606-fff5-4f06-9fc6-dddef374f222)

![Screenshot 2025-01-03 at 12 03 19 PM](https://github.com/user-attachments/assets/116f64be-0344-4b1a-af7c-3cfe0de38f12)

---

This pull request includes several changes to the `theStockTimes` game, adding a new feature that allows players to convert losses into gains and refactoring some components for better code organization and clarity. 

### New Feature: Loss into Gain

* Added a new optional `lossIntoGain` property to the `TransactionHistory` interface to track transactions where losses are converted into gains.
* Updated the `StockTimesPlayer` interface to include a `lossIntoGain` store power.
* Modified the `TheStockTimesServer` class to initialize the `lossIntoGain` store power with default values.
* Implemented the `SellPlayerStock` component to handle selling stocks and converting losses into gains.
* Updated the `ActivateStorePower` component to support the new `lossIntoGain` store power with customizable button text.
* Enhanced the `StockTimesStore` component to display the new `lossIntoGain` store power with a description and cooldown information.

### Code Refactoring

* Refactored the `PlayerStocks` component to import and use the new `SellPlayerStock` component.
* Adjusted the `PlayerStocks` component to pass the `atLoss` prop to the `SellPlayerStock` component.

### Additional Changes

* Added a new script `"deploy:restart"` to the `package.json` file to restart Docker containers.