### PR TITLE
Add pausing the game and wire up the store powers to it

### DIFF
--- a/packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx
@@ -1,5 +1,5 @@
 import { ScrollArea } from "@radix-ui/themes";
-import { Flex } from "../components";
+import { Flex, Text } from "../components";
 import { AvailableStocks } from "./components/AvailableStocks";
 import { Clock } from "./components/cycle/Clock";
 import { DayArticles } from "./components/DayArticles";
@@ -7,6 +7,7 @@ import { FinalScoreboard } from "./components/FinalScoreboard";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import styles from "./DisplayTheStockTimes.module.scss";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
+import { PauseAndPlay } from "./components/cycle/PauseAndPlay";
 
 export const DisplayTheStockTimes = () => {
   const gameInfo = useGameStateSelector((s) => s.gameStateSlice.gameInfo);
@@ -20,10 +21,28 @@ export const DisplayTheStockTimes = () => {
     return;
   }
 
+  if (gameState.cycle.state === "paused") {
+    return (
+      <Flex align="center" flex="1" gap="3" justify="center">
+        <Text color="gray">The game is paused</Text>
+        <Flex>
+          <PauseAndPlay />
+        </Flex>
+      </Flex>
+    );
+  }
+
   return (
     <Flex className={styles.mainContainer} flex="1">
-      <Flex align="center" className={styles.clock} gap="2">
+      <Flex
+        align="center"
+        className={styles.clock}
+        direction="column"
+        flex="1"
+        gap="2"
+      >
         <Clock cycle={gameState.cycle} />
+        <PauseAndPlay />
       </Flex>
       <Flex flex="1">
         <PlayerPortfolio />

--- a/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
+++ b/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "../components";
+import { Flex, Text } from "../components";
 import { Clock } from "./components/cycle/Clock";
 import { FinalScoreboard } from "./components/FinalScoreboard";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
@@ -9,6 +9,14 @@ export const StockTimesGlobalScreen = () => {
 
   if (gameState === undefined) {
     return;
+  }
+
+  if (gameState.cycle.state === "paused") {
+    return (
+      <Flex align="center" flex="1" justify="center">
+        <Text color="gray">The game is paused</Text>
+      </Flex>
+    );
   }
 
   return (

--- a/packages/games/src/frontend/theStockTimes/components/cycle/PauseAndPlay.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/PauseAndPlay.tsx
@@ -1,0 +1,53 @@
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { Button } from "../../../components";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { PauseIcon, PlayIcon } from "@radix-ui/react-icons";
+
+export const PauseAndPlay = () => {
+  const dispatch = useGameStateDispatch();
+
+  const gameState = useGameStateSelector((s) => s.gameStateSlice.gameState);
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+
+  if (gameState?.cycle === undefined || player === undefined) {
+    return;
+  }
+
+  const togglePause = () => {
+    const newState = gameState.cycle.state === "paused" ? "playing" : "paused";
+    const { currentTime } = cycleTime(gameState.cycle);
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          cycle: {
+            ...gameState.cycle,
+            lastUpdatedAt: new Date().toISOString(),
+            seedTime:
+              newState === "paused" ? currentTime : gameState.cycle.seedTime,
+            startTime:
+              newState === "playing"
+                ? new Date().toISOString()
+                : gameState.cycle.startTime,
+            state: newState
+          }
+        },
+        player
+      )
+    );
+  };
+
+  return (
+    <Button
+      onClick={togglePause}
+      style={{ paddingBottom: "5px", paddingTop: "5px" }}
+      variant={gameState.cycle.state === "paused" ? "solid" : "outline"}
+    >
+      {gameState.cycle.state === "paused" ? <PlayIcon /> : <PauseIcon />}
+    </Button>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
@@ -1,3 +1,4 @@
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 import {
   OwnedStock,
   TransactionHistory
@@ -97,6 +98,7 @@ export const SellPlayerStock = ({
 
     const lossIntoGainCooldown =
       (cycle.dayTime + cycle.nightTime) * SELL_INTO_GAIN_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
 
     dispatch(
       updateTheStockTimesGameState(
@@ -114,9 +116,7 @@ export const SellPlayerStock = ({
                 ...playerPortfolio.storePowers,
                 lossIntoGain: {
                   cooldownTime: lossIntoGainCooldown,
-                  unlocksAt: new Date(
-                    Date.now() + lossIntoGainCooldown
-                  ).toISOString()
+                  usedAt
                 }
               },
               transactionHistory: [

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
@@ -1,3 +1,4 @@
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 import { Flex, Text } from "../../../components";
 import {
   selectPlayerPortfolio,
@@ -14,7 +15,7 @@ import styles from "./StockTimesStore.module.scss";
 
 const LOAN_AMOUNT = 0.25;
 const LOAN_DEBT = 1.2;
-const LOAN_COOLDOWN = 2.5;
+const LOAN_COOLDOWN = 0.15;
 
 export const StockTimesStore = () => {
   const dispatch = useGameStateDispatch();
@@ -43,6 +44,7 @@ export const StockTimesStore = () => {
     }
 
     const loanCooldown = (cycle.dayTime + cycle.nightTime) * LOAN_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
 
     dispatch(
       updateTheStockTimesGameState(
@@ -57,7 +59,7 @@ export const StockTimesStore = () => {
                 ...playerPortfolio.storePowers,
                 loan: {
                   cooldownTime: loanCooldown,
-                  unlocksAt: new Date(Date.now() + loanCooldown).toISOString()
+                  usedAt
                 }
               }
             }

--- a/packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/cycleTime.ts
@@ -19,6 +19,7 @@ export function useCycleTime(cycle: StockTimesCycle | undefined): CycleTime {
   if (cycle === undefined) {
     return {
       currentCycle: "day",
+      currentTime: 0,
       day: 0,
       time: 0,
       timeFraction: 0

--- a/packages/games/src/frontend/theStockTimes/hooks/storePower.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/storePower.ts
@@ -2,11 +2,13 @@ import { useEffect, useState } from "react";
 import { StockTimesPlayer } from "../../../backend/theStockTimes/theStockTimes";
 import { useGameStateSelector } from "../store/theStockTimesRedux";
 import { selectPlayerPortfolio } from "../store/selectors";
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 
 export function useStorePower(
   storePower: keyof StockTimesPlayer["storePowers"]
 ) {
   const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
 
   const [_, setCounter] = useState(0);
 
@@ -20,7 +22,7 @@ export function useStorePower(
     };
   }, []);
 
-  if (playerPortfolio === undefined) {
+  if (playerPortfolio === undefined || cycle === undefined) {
     return {
       isAvailable: false,
       timeLeft: 0
@@ -28,19 +30,32 @@ export function useStorePower(
   }
 
   const accordingStorePower = playerPortfolio.storePowers[storePower];
+  if (accordingStorePower === undefined) {
+    return {
+      isAvailable: false,
+      timeLeft: 0
+    };
+  }
 
-  const unlocksAt =
-    accordingStorePower.unlocksAt !== undefined
-      ? new Date(accordingStorePower.unlocksAt)
-      : new Date();
-  const isAvailable = new Date().valueOf() >= unlocksAt.valueOf();
+  const { currentTime } = cycleTime(cycle);
 
-  const percentTimeLeft =
-    Math.max(unlocksAt.valueOf() - new Date().valueOf(), 0) /
-    (accordingStorePower.cooldownTime ?? 1);
+  const availableOn =
+    (accordingStorePower.usedAt ?? 0) + (accordingStorePower.cooldownTime ?? 0);
+
+  const isAvailable = availableOn < currentTime;
+  const timeLeft = (() => {
+    if (isAvailable) {
+      return 0;
+    }
+
+    const timePassed = currentTime - (accordingStorePower.usedAt ?? 0);
+    const percentTime = timePassed / (accordingStorePower.cooldownTime ?? 1);
+
+    return 100 * percentTime;
+  })();
 
   return {
     isAvailable,
-    timeLeft: 100 - percentTimeLeft * 100
+    timeLeft
   };
 }

--- a/packages/games/src/shared/theStockTimes/cycleTime.ts
+++ b/packages/games/src/shared/theStockTimes/cycleTime.ts
@@ -4,15 +4,21 @@ export type CurentCyle = "day" | "night";
 
 export interface CycleTime {
   currentCycle: CurentCyle;
+  /**
+   * The current time in milliseconds since the game started. Used for a seed value when pausing the game.
+   */
+  currentTime: number;
   day: number;
   time: number;
   timeFraction: number;
 }
 
 export function cycleTime(cycle: StockTimesCycle, value?: number): CycleTime {
+  const initialTime =
+    value === undefined ? new Date().valueOf() : new Date(value).valueOf();
   const currentTime =
-    (value === undefined ? new Date().valueOf() : new Date(value).valueOf()) -
-    new Date(cycle.startTime).valueOf();
+    initialTime - new Date(cycle.startTime).valueOf() + cycle.seedTime;
+
   const totalTimePerDay = cycle.dayTime + cycle.nightTime;
 
   const day = Math.floor(currentTime / totalTimePerDay) + 1;
@@ -23,6 +29,7 @@ export function cycleTime(cycle: StockTimesCycle, value?: number): CycleTime {
 
   return {
     currentCycle,
+    currentTime,
     day,
     time,
     timeFraction


### PR DESCRIPTION
<img width="178" alt="Screenshot 2025-01-04 at 12 41 03 PM" src="https://github.com/user-attachments/assets/922ddedf-e012-4f6c-915a-163f3c5e2c19" />
<img width="404" alt="Screenshot 2025-01-04 at 12 41 05 PM" src="https://github.com/user-attachments/assets/307032e9-aa3c-42e9-8834-c799fd05f67b" />

---

This pull request introduces significant updates to the `TheStockTimes` game, focusing on adding a pause/play feature and enhancing the handling of game cycles and power-ups. The changes span both the backend and frontend components of the game. Below is a summary of the most important changes:

### Backend Changes:

* `StockTimesCycle` interface has been extended to include new properties such as `seedTime`, `state`, and `lastUpdatedAt` to manage the game state and timing more effectively. (`packages/games/src/backend/theStockTimes/theStockTimes.ts`) [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L16-R40) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R69-R76)
* `TheStockTimesServer` class has been updated to initialize and handle the new cycle properties and manage the game state transitions. (`packages/games/src/backend/theStockTimes/theStockTimes.ts`) [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L110-R143) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L148-R183) [[3]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R220-R223)

### Frontend Changes:

* Added a new `PauseAndPlay` component to allow users to pause and resume the game. This component updates the game state accordingly and displays the current state. (`packages/games/src/frontend/theStockTimes/components/cycle/PauseAndPlay.tsx`)
* Updated the `DisplayTheStockTimes` and `StockTimesGlobalScreen` components to handle the paused state by showing a message and providing a button to resume the game. (`packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx`, `packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx`) [[1]](diffhunk://#diff-26112bcd800154b71500a975033d1172c6bca44f776c1f9a42127141cefdf023L2-R10) [[2]](diffhunk://#diff-26112bcd800154b71500a975033d1172c6bca44f776c1f9a42127141cefdf023R24-R45) [[3]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7L1-R1) [[4]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R14-R21)

### Utility and Hook Updates:

* Modified the `cycleTime` function to include a `currentTime` property, which tracks the time elapsed since the game started, accounting for pauses. (`packages/games/src/shared/theStockTimes/cycleTime.ts`) [[1]](diffhunk://#diff-ca59685e2fbd545a52e2b85e36264782b6e8e59d4c45af8c5dc0b328fbbdcacdR7-R21) [[2]](diffhunk://#diff-ca59685e2fbd545a52e2b85e36264782b6e8e59d4c45af8c5dc0b328fbbdcacdR32)
* Updated various hooks and components to use the new `currentTime` property and handle power-up cooldowns more accurately. (`packages/games/src/frontend/theStockTimes/hooks/storePower.ts`, `packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx`, `packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx`) [[1]](diffhunk://#diff-5d171b83e15a09455eebb78b307078b5593f481df798aac58d7754c346191c4aR5-R11) [[2]](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09R1) [[3]](diffhunk://#diff-95b200133c106bea95b10c0b08a4581404ec746fae104af0c64af374b11357c4R1)

These changes collectively enhance the game's functionality by allowing players to pause and resume gameplay and ensuring that all time-based mechanics, such as power-up cooldowns, are accurately maintained.