### PR TITLE
Add ability to transfer cash

### DIFF
--- a/packages/frontend/src/lib/radix/Select.tsx
+++ b/packages/frontend/src/lib/radix/Select.tsx
@@ -1,25 +1,27 @@
 import { Select as RadixComponent } from "@radix-ui/themes";
 
-export interface SelectProps {
+export interface SelectProps<ItemValue extends string> {
   defaultValue?: string;
-  items: Array<{ label: string; value: string }>;
-  onChange: (value: string) => void;
-  value: string;
+  items: Array<{ label: string; value: ItemValue }>;
+  onChange: (value: ItemValue) => void;
+  value: ItemValue | undefined;
 }
 
-export const Select = ({
+export const Select = <ItemValue extends string>({
   defaultValue,
   onChange,
   items,
   value
-}: SelectProps) => {
+}: SelectProps<ItemValue>) => {
   return (
     <RadixComponent.Root
       defaultValue={defaultValue}
       onValueChange={onChange}
       value={value}
     >
-      <RadixComponent.Trigger style={{ flex: 1 }} />
+      <RadixComponent.Trigger
+        style={{ flex: 1, paddingBottom: "3px", paddingTop: "3px" }}
+      />
       <RadixComponent.Content>
         {items.map((item) => (
           <RadixComponent.Item key={item.value} value={item.value}>

--- a/packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx
+++ b/packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx
@@ -8,8 +8,11 @@ import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import styles from "./DisplayTheStockTimes.module.scss";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 import { PauseAndPlay } from "./components/cycle/PauseAndPlay";
+import { usePendingPlayerChanges } from "./hooks/pendingPlayerChanges";
 
 export const DisplayTheStockTimes = () => {
+  usePendingPlayerChanges();
+
   const gameInfo = useGameStateSelector((s) => s.gameStateSlice.gameInfo);
   const gameState = useGameStateSelector((s) => s.gameStateSlice.gameState);
 

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
@@ -17,6 +17,7 @@ import {
   LOCK_UP_TIME
 } from "../singleStock/PurchaseStock";
 import { SELL_INTO_GAIN_COOLDOWN } from "../playerPortfolio/SellPlayerStock";
+import { TRANSFER_CASH_COOLDOWN, TransferCash } from "./powers/TransferCash";
 
 const LOAN_AMOUNT = 0.25;
 const LOAN_DEBT = 1.2;
@@ -100,6 +101,29 @@ export const StockTimesStore = () => {
           <Flex justify="end">
             <Text color="gray" size="2">
               {LOAN_COOLDOWN} day cooldown
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex className={styles.storePower} direction="column">
+        <Flex align="center" className={styles.powerName} p="2">
+          <Flex flex="1">
+            <Text size="4" weight="bold">
+              Transfer cash
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex direction="column" gap="1" p="2">
+          <Text color="gray" size="2">
+            Move cash from your portfolio to a teammate's, up to 50% of your
+            current cash.
+          </Text>
+          <Flex py="2">
+            <TransferCash />
+          </Flex>
+          <Flex justify="end">
+            <Text color="gray" size="2">
+              {TRANSFER_CASH_COOLDOWN} day cooldown
             </Text>
           </Flex>
         </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/store/powers/TransferCash.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/powers/TransferCash.tsx
@@ -1,0 +1,139 @@
+import { RocketIcon } from "@radix-ui/react-icons";
+import { PlayerId } from "@resync-games/api";
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { useState } from "react";
+import { Button, Flex, Select, Text, TextField } from "../../../../components";
+import { selectPlayerPortfolio, selectTeams } from "../../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../../store/theStockTimesRedux";
+import { ActivateStorePower } from "../ActivateStorePower";
+
+export const TRANSFER_CASH_COOLDOWN = 0.5;
+
+export const TransferCash = () => {
+  const dispatch = useGameStateDispatch();
+
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const pendingPlayerActions = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.pendingPlayerActions
+  );
+
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+  const teams = useGameStateSelector(selectTeams);
+
+  const playersOnTeam = teams[playerPortfolio?.team ?? ""]?.players ?? [];
+  const filteredPlayers = playersOnTeam.filter(
+    (p) => p.playerId !== player?.playerId
+  );
+
+  const [playerSelector, setPlayerSelector] = useState<PlayerId | undefined>(
+    filteredPlayers[0]?.playerId
+  );
+  const [cashSelector, setCashSelector] = useState<string>("0");
+
+  if (playerPortfolio === undefined || filteredPlayers.length === 0) {
+    return <Text color="gray">No teammates available</Text>;
+  }
+
+  const totalCash = parseFloat(cashSelector);
+
+  const transferCash = () => {
+    if (
+      player === undefined ||
+      cycle === undefined ||
+      playerSelector === undefined ||
+      pendingPlayerActions?.[playerSelector]?.cashInflux !== undefined ||
+      Number.isNaN(totalCash)
+    ) {
+      return;
+    }
+
+    const newPlayerCash = playerPortfolio.cash - totalCash;
+
+    const transferCooldown =
+      (cycle.dayTime + cycle.nightTime) * TRANSFER_CASH_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          pendingPlayerActions: {
+            [playerSelector]: {
+              cashInflux: totalCash,
+              lastUpdatedAt: new Date().toISOString()
+            }
+          },
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              cash: newPlayerCash,
+              lastUpdatedAt: new Date().toISOString(),
+              storePowers: {
+                ...playerPortfolio.storePowers,
+                transferCash: {
+                  cooldownTime: transferCooldown,
+                  usedAt
+                }
+              }
+            }
+          }
+        },
+        player
+      )
+    );
+
+    setCashSelector("0");
+  };
+
+  const canActivate = (() => {
+    if (playerSelector === undefined) {
+      return false;
+    }
+
+    return (
+      pendingPlayerActions?.[playerSelector]?.cashInflux === undefined &&
+      totalCash <= playerPortfolio.cash * 0.5
+    );
+  })();
+
+  const setToHalf = () =>
+    setCashSelector(
+      (Math.round((playerPortfolio.cash / 2) * 100) / 100).toString()
+    );
+
+  return (
+    <Flex direction="column" flex="1" gap="2">
+      <Select<PlayerId>
+        items={filteredPlayers.map((player) => ({
+          label: player.displayName,
+          value: player.playerId
+        }))}
+        onChange={setPlayerSelector}
+        value={playerSelector}
+      />
+      <Flex align="center" flex="1" gap="2">
+        <Flex gap="2">
+          <TextField
+            onChange={setCashSelector}
+            type="number"
+            value={cashSelector}
+          />
+          <Button onClick={setToHalf} variant="outline">
+            <RocketIcon />
+          </Button>
+        </Flex>
+        <Flex flex="1">
+          <ActivateStorePower
+            disabled={!canActivate}
+            onClick={transferCash}
+            storePower="transferCash"
+          />
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts
@@ -1,0 +1,64 @@
+import { PlayerId } from "@resync-games/api";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../store/theStockTimesRedux";
+import { useEffect } from "react";
+import { selectPlayerPortfolio } from "../store/selectors";
+import {
+  StockTimesPendingPlayerActions,
+  StockTimesPlayer
+} from "../../../backend/theStockTimes/theStockTimes";
+
+export function usePendingPlayerChanges() {
+  const dispatch = useGameStateDispatch();
+
+  const gameState = useGameStateSelector((s) => s.gameStateSlice.gameState);
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+
+  const pendingPlayerActions =
+    gameState?.pendingPlayerActions[player?.playerId ?? ("" as PlayerId)];
+
+  const processActionsAndPortfolio = (
+    newPlayerPortfolio: StockTimesPlayer,
+    newPlayerActions: StockTimesPendingPlayerActions
+  ) => {
+    if (player === undefined) {
+      return;
+    }
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          pendingPlayerActions: {
+            [player.playerId]: newPlayerActions
+          },
+          players: {
+            [player.playerId]: newPlayerPortfolio
+          }
+        },
+        player
+      )
+    );
+  };
+
+  useEffect(() => {
+    if (pendingPlayerActions === undefined || playerPortfolio === undefined) {
+      return;
+    }
+
+    const newPlayerActions = { ...pendingPlayerActions };
+    const newPlayerPortfolio = { ...playerPortfolio };
+    if (pendingPlayerActions.cashInflux !== undefined) {
+      newPlayerPortfolio.cash += pendingPlayerActions.cashInflux;
+      newPlayerPortfolio.lastUpdatedAt = new Date().toISOString();
+
+      newPlayerActions.cashInflux = undefined;
+      newPlayerActions.lastUpdatedAt = new Date().toISOString();
+    }
+
+    processActionsAndPortfolio(newPlayerPortfolio, newPlayerActions);
+  }, [pendingPlayerActions?.lastUpdatedAt]);
+}


### PR DESCRIPTION
Adds the ability to transfer cash from one player to another (on the same team). It does this by subtracting the cash from the sending player, appending it to the "pending actions" on the receiving player. Then when the receiving player's device gets it, it adds the cash to that player's balance, resolves the state, and submits the update. We do this to ensure each player's device is the source of truth for their portfolio - this will handle race conditions between the sending player sending cash and the receiving player selling stock (in theory).

We also don't allow sending cash to someone who has a pending cash influx to avoid multiple people sending cash to conflict.

<img width="378" alt="image" src="https://github.com/user-attachments/assets/599f1c1a-0cbc-4883-9de6-8b1287869121" />

This pull request includes changes to the `Select` component in the frontend and introduces a new "Transfer Cash" feature in the `TheStockTimes` game. The most important changes include updating the `Select` component to be more flexible with generic types, adding the "Transfer Cash" feature, and handling pending player actions in the game state.

### Frontend Component Updates:

* [`packages/frontend/src/lib/radix/Select.tsx`](diffhunk://#diff-f5ba5e7a35ccb9c643ef4ec9b3d8e46e9f5165492d66f8addc6fa345f9b89292L3-R24): Updated the `Select` component to use a generic `ItemValue` type for better type safety and flexibility.

### New "Transfer Cash" Feature:

* [`packages/games/src/backend/theStockTimes/theStockTimes.ts`](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R101): Added the `transferCash` power-up and related interfaces to handle cash transfers between players. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R101) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R123-R138) [[3]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R175) [[4]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R214-R226)
* [`packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx`](diffhunk://#diff-95b200133c106bea95b10c0b08a4581404ec746fae104af0c64af374b11357c4R20): Integrated the "Transfer Cash" feature into the store interface, allowing players to transfer cash to teammates. [[1]](diffhunk://#diff-95b200133c106bea95b10c0b08a4581404ec746fae104af0c64af374b11357c4R20) [[2]](diffhunk://#diff-95b200133c106bea95b10c0b08a4581404ec746fae104af0c64af374b11357c4R108-R130)
* [`packages/games/src/frontend/theStockTimes/components/store/powers/TransferCash.tsx`](diffhunk://#diff-4a9bea33849d6be3cb6f4a2a246c1fc369fed5aeec8303a6b74e6ad434cfb47cR1-R139): Implemented the `TransferCash` component to handle the UI and logic for transferring cash between players.

### Handling Pending Player Actions:

* [`packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts`](diffhunk://#diff-0bbe6b7430d9f70b975bf03067bd98bcb956366fa1f39b3e492b35d0f29639b4R1-R64): Added a hook to process pending player actions, ensuring that cash transfers are correctly reflected in the game state.
* [`packages/games/src/frontend/theStockTimes/DisplayTheStockTimes.tsx`](diffhunk://#diff-26112bcd800154b71500a975033d1172c6bca44f776c1f9a42127141cefdf023R11-R15): Utilized the new hook to manage pending player changes in the game display component.
