### PR TITLE
Add stock corruption power

### DIFF
--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -108,6 +108,10 @@ export interface StockTimesPlayer extends WithTimestamp {
    */
   storePowers: {
     /**
+     * Allows the player to corrupt a news article, which changes a stock's article impact to minimal.
+     */
+    corruptedStock: StorePowerUpUsage;
+    /**
      * Allows buying 2x the stock for the price of 1x.
      */
     discountBuy: StorePowerUpUsage;
@@ -138,6 +142,7 @@ export type StockArticleImpact = -2 | -1 | 0 | 1 | 2;
 
 export interface StockArticle extends WithTimestamp {
   addedOn: number;
+  corruptedOn?: number;
   description: string;
   impact: StockArticleImpact;
   title: string;
@@ -242,6 +247,10 @@ export class TheStockTimesServer
         lastUpdatedAt: new Date().toISOString(),
         ownedStocks: {},
         storePowers: {
+          corruptedStock: {
+            cooldownTime: undefined,
+            usedAt: undefined
+          },
           discountBuy: {
             cooldownTime: undefined,
             usedAt: undefined
@@ -412,6 +421,13 @@ export class TheStockTimesServer
   }
 
   private accountForNewsArticle(latestNewsArticle: StockArticle | undefined) {
+    if (latestNewsArticle?.corruptedOn !== undefined) {
+      return {
+        percentOfLastPrice: 0.015,
+        probabilityOfIncrease: 0.5
+      };
+    }
+
     if (latestNewsArticle?.impact === 1) {
       return {
         percentOfLastPrice: 0.05,

--- a/packages/games/src/frontend/theStockTimes/StockTimesTutorial.tsx
+++ b/packages/games/src/frontend/theStockTimes/StockTimesTutorial.tsx
@@ -59,13 +59,13 @@ export const StockTimesTutorial = ({
       </Flex>
       <Flex direction="column" gap="1">
         <Text color="gray" size="2">
-          Store
+          Store and Sabotage
         </Text>
         <Text>
-          In addition to buying and sell stocks, there is a store where you can
-          purchase special powers. Be sure to check it out. Some powers will
-          boost your portfolio, and others will let you mess with your
-          opponents.
+          In addition to buying and sell stocks, there is a store and a sabotage
+          screen where you can purchase special powers. Be sure to check them
+          out. Some powers will boost your portfolio, and others will let you
+          mess with your opponents.
         </Text>
       </Flex>
       <Flex direction="column" gap="1">
@@ -83,7 +83,7 @@ export const StockTimesTutorial = ({
         <Text>
           In addition, we recommend keeping a close eye on how your opponents
           portfolios are doing. If you see them doing well, there might be some
-          options in the store to mess with their success. Good luck!
+          options in the sabotage tab to mess with their success. Good luck!
         </Text>
       </Flex>
     </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
@@ -16,6 +16,10 @@ export const DayArticles = () => {
     setSelectedDay(0);
   }, [lastestAddedOn]);
 
+  const anyCorrupted = articles
+    .map((a) => a?.[selectedDay]?.corruptedOn ?? "")
+    .join("");
+
   const viewingArticles: StockArticle[] = useMemo(() => {
     const collapsedArticles = articles.map((a) => a?.[selectedDay]);
     const filteredArticles = collapsedArticles.filter(
@@ -36,7 +40,7 @@ export const DayArticles = () => {
     }
 
     return shuffle(filteredArticles);
-  }, [lastestAddedOn, selectedDay]);
+  }, [lastestAddedOn, selectedDay, anyCorrupted]);
 
   return (
     <Flex
@@ -81,11 +85,17 @@ export const DayArticles = () => {
           >
             <Flex justify="between">
               <Text size="4" weight="bold">
-                {article.title}
+                {article.corruptedOn !== undefined
+                  ? "CORRUPTED"
+                  : article.title}
               </Text>
             </Flex>
             <Flex>
-              <Text color="gray">{article.description}</Text>
+              <Text color="gray">
+                {article.corruptedOn !== undefined
+                  ? `[CORRUPTED] ${article.title}`
+                  : article.description}
+              </Text>
             </Flex>
           </Flex>
         ))}

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../store/selectors";
 import { useGameStateSelector } from "../../store/theStockTimesRedux";
 import { displayDollar } from "../../utils/displayDollar";
+import { Sabotage } from "../sabotage/Sabotage";
 import { StockTimesStore } from "../store/StockTimesStore";
 import styles from "./PlayerPortfolio.module.scss";
 import { PlayerStocks } from "./PlayerStocks";
@@ -104,6 +105,7 @@ export const PlayerPortfolio = () => {
         <Tabs.List>
           <Tabs.Trigger value="your-portfolio">Your portfolio</Tabs.Trigger>
           <Tabs.Trigger value="store">Store</Tabs.Trigger>
+          <Tabs.Trigger value="sabotage">Sabotage</Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="your-portfolio">
           <Flex direction="column" mt="2">
@@ -114,6 +116,11 @@ export const PlayerPortfolio = () => {
         <Tabs.Content value="store">
           <Flex direction="column" mt="2">
             <StockTimesStore />
+          </Flex>
+        </Tabs.Content>
+        <Tabs.Content value="sabotage">
+          <Flex direction="column" mt="2">
+            <Sabotage />
           </Flex>
         </Tabs.Content>
       </Tabs.Root>

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/CorruptStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/CorruptStock.tsx
@@ -1,0 +1,116 @@
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { useMemo, useState } from "react";
+import { selectPlayerPortfolio } from "../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { ActivateStorePower } from "../store/ActivateStorePower";
+import { Flex, Select } from "../../../components";
+
+export const CORRUPT_STOCK_COOLDOWN = 3;
+
+export const CorruptStock = () => {
+  const dispatch = useGameStateDispatch();
+
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+
+  const newsArticles = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.newsArticles
+  );
+  const stocks = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.stocks ?? {}
+  );
+
+  const [stockSelector, setStockSelector] = useState("");
+
+  const sortedStock = useMemo(() => {
+    return Object.entries(stocks).sort(([aSymbol], [bSymbol]) => {
+      return aSymbol.localeCompare(bSymbol);
+    });
+  }, [stocks]);
+
+  const onCorruptStock = () => {
+    if (
+      player === undefined ||
+      cycle === undefined ||
+      playerPortfolio === undefined ||
+      stockSelector === undefined ||
+      stockSelector === ""
+    ) {
+      return;
+    }
+
+    const corruptedStockCooldown =
+      (cycle.dayTime + cycle.nightTime) * CORRUPT_STOCK_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
+
+    const newArticlesForStock = (
+      newsArticles?.articles?.[stockSelector] ?? []
+    ).slice();
+    const maybeFirstArticle = newArticlesForStock[0];
+    if (maybeFirstArticle === undefined) {
+      return;
+    }
+
+    newArticlesForStock[0] = {
+      ...maybeFirstArticle,
+      corruptedOn: usedAt,
+      lastUpdatedAt: new Date().toISOString()
+    };
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          newsArticles: {
+            ...newsArticles,
+            articles: {
+              ...(newsArticles?.articles ?? {}),
+              [stockSelector]: newArticlesForStock
+            },
+            lastUpdatedAt: new Date().toISOString()
+          },
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              lastUpdatedAt: new Date().toISOString(),
+              storePowers: {
+                ...playerPortfolio.storePowers,
+                corruptedStock: {
+                  cooldownTime: corruptedStockCooldown,
+                  usedAt
+                }
+              }
+            }
+          }
+        },
+        player
+      )
+    );
+
+    setStockSelector("");
+  };
+
+  return (
+    <Flex direction="column" flex="1" gap="2">
+      <Select
+        items={sortedStock.map(([symbol, stock]) => ({
+          label: `[${symbol}] ${stock.title}`,
+          value: symbol
+        }))}
+        onChange={setStockSelector}
+        value={stockSelector}
+      />
+      <Flex flex="1">
+        <ActivateStorePower
+          disabled={stockSelector === undefined || stockSelector === ""}
+          onClick={onCorruptStock}
+          storePower="corruptedStock"
+        />
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.module.scss
@@ -1,0 +1,10 @@
+@use "@/styles/variables.scss" as vars;
+
+.sabotagePower {
+    border-radius: 3px;
+    border: 1px solid vars.$muted-font;
+}
+
+.powerName {
+    border-bottom: 1px solid vars.$muted-font;
+}

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.tsx
@@ -1,0 +1,34 @@
+import { Flex, Text } from "../../../components";
+import { CORRUPT_STOCK_COOLDOWN, CorruptStock } from "./CorruptStock";
+import styles from "./Sabotage.module.scss";
+
+export const Sabotage = () => {
+  return (
+    <Flex direction="column" gap="2">
+      <Flex className={styles.sabotagePower} direction="column">
+        <Flex align="center" className={styles.powerName} p="2">
+          <Flex flex="1">
+            <Text size="4" weight="bold">
+              Corrupt a stock
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex direction="column" gap="1" p="2">
+          <Text color="gray" size="2">
+            Corrupts a stock's news article for the day, if there has been one
+            published. Use this to prevent the opponents from using the article
+            to their advantage, or to perhaps cut your losses.
+          </Text>
+          <Flex py="2">
+            <CorruptStock />
+          </Flex>
+          <Flex justify="end">
+            <Text color="gray" size="2">
+              {CORRUPT_STOCK_COOLDOWN} day cooldown
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};


### PR DESCRIPTION
Adds the first sabotage power, which lets a user corrupt a stock's daily news article. Note the cooldown is actually 3 days not 0.15 days.

<img width="846" alt="Screenshot 2025-01-06 at 10 24 37 PM" src="https://github.com/user-attachments/assets/6cf9600a-b1e2-433c-a707-2fcc24e9c159" />

This pull request introduces a new feature called "Corrupt Stock" to the game "The Stock Times." This feature allows players to corrupt a news article, affecting the stock's impact. The changes include updates to both the backend and frontend components to support this new functionality.

Backend changes:
* Added the `corruptedStock` store power to the `StockTimesPlayer` interface, allowing players to corrupt a news article.
* Updated the `StockArticle` interface to include an optional `corruptedOn` field, indicating when an article was corrupted.
* Modified the `TheStockTimesServer` class to initialize the `corruptedStock` power and handle corrupted articles in the `accountForNewsArticle` method. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R250-R253) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R424-R430)

Frontend changes:
* Updated the `StockTimesTutorial` component to include information about the new sabotage feature. [[1]](diffhunk://#diff-855a6e3e5f2c36b462c49e5485896d89d317c5d8139cc43d9cd9dcb1f6528212L62-R68) [[2]](diffhunk://#diff-855a6e3e5f2c36b462c49e5485896d89d317c5d8139cc43d9cd9dcb1f6528212L86-R86)
* Added a new `Sabotage` tab in the `PlayerPortfolio` component, which includes the `CorruptStock` component for using the corrupt stock power. [[1]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R9) [[2]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R108) [[3]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3R121-R125)
* Implemented the `CorruptStock` component to allow players to select and corrupt a stock, updating the game state accordingly.
* Added styles for the `Sabotage` component in `Sabotage.module.scss`.
* Created the `Sabotage` component to display the corrupt stock power and its description.
