### PR TITLE
Prevent double buying if there isn't enough time

### DIFF
--- a/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
@@ -93,12 +93,25 @@ export const PurchaseStock = ({
     setTotalPurchase("0");
   };
 
+  const areThereEnoughLockUpDays = () => {
+    if (cycle === undefined) {
+      return false;
+    }
+
+    const availabilityTime = (cycle.dayTime + cycle.nightTime) * LOCK_UP_TIME;
+    const dateAtCompletion = new Date(Date.now() + availabilityTime);
+
+    const { day } = cycleTime(cycle, dateAtCompletion.valueOf());
+    return day < cycle.endDay;
+  };
+
   const purchaseDiscountStock = () => {
     if (
       playerPortfolio === undefined ||
       player === undefined ||
       currentStockPrice === undefined ||
-      cycle === undefined
+      cycle === undefined ||
+      !areThereEnoughLockUpDays()
     ) {
       return;
     }
@@ -229,7 +242,9 @@ export const PurchaseStock = ({
         <Flex style={{ width: "30%" }}>
           <Flex direction="column" flex="1" gap="2">
             <Button
-              disabled={quantity <= 0 || leftOverCash < 0}
+              disabled={
+                quantity <= 0 || leftOverCash < 0 || !areThereEnoughLockUpDays()
+              }
               onClick={purchaseStock}
             >
               Buy {quantity} stocks

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
@@ -169,6 +169,10 @@ export const StockTimesStore = () => {
             sale during this time. Activate this option on the purchase stock
             screen.
           </Text>
+          <Text color="gray" size="2">
+            Note this will be disabled at the start of day{" "}
+            {(cycle?.endDay ?? 0) - LOCK_UP_TIME}.
+          </Text>
           <Flex justify="end">
             <Text color="gray" size="2">
               {DISCOUNT_BUY_COOLDOWN} day cooldown


### PR DESCRIPTION
Patching an exploit. At the last minute you could 2x your portfolio using this and not have to wait the 2 days.

---

This pull request includes changes to the `PurchaseStock` component and the `StockTimesStore` component in the `packages/games/src/frontend/theStockTimes` directory. The changes ensure that stock purchases are only allowed if there are enough lock-up days remaining and provide additional user information regarding the lock-up period.

Changes to `PurchaseStock` component:

* Added a function `areThereEnoughLockUpDays` to check if there are sufficient lock-up days remaining before allowing a stock purchase.
* Modified the `purchaseDiscountStock` function to incorporate the `areThereEnoughLockUpDays` check.
* Updated the `disabled` condition for the "Buy stocks" button to include the `areThereEnoughLockUpDays` check.

Changes to `StockTimesStore` component:

* Added a text note to inform users that the option will be disabled at the start of a specific day, calculated based on the lock-up time.