### PR TITLE
Add cash lock to sabotage options

### DIFF
--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -98,6 +98,10 @@ export interface StockTimesPlayer extends WithTimestamp {
    */
   debt: number;
   /**
+   * Prevents the player from spending cash
+   */
+  lockCashSpending?: PowerLock;
+  /**
    * The stocks the player owns. This will be used to determine the player's total value.
    */
   ownedStocks: {
@@ -119,6 +123,10 @@ export interface StockTimesPlayer extends WithTimestamp {
      * Allows the player to take out a loan of some % of everyone's average value.
      */
     loan: StorePowerUpUsage;
+    /**
+     * Prevents a player from spending their cash for a set amount of time.
+     */
+    lockCashSpending: StorePowerUpUsage;
     /**
      * Converts the losses on a holding into gains.
      */
@@ -155,8 +163,20 @@ export interface StockTimesNewsArticle extends WithTimestamp {
   lastDay: number;
 }
 
+export interface PowerLock {
+  /**
+   * The time in milliseconds when the stock will be available again, after the lockedAt time.
+   */
+  availabilityTime: number;
+  /**
+   * The current time on the clock when the stock was locked.
+   */
+  lockedAt: number;
+}
+
 export interface StockTimesPlayerActions extends WithTimestamp {
   cashInflux?: number;
+  lockCashSpending?: PowerLock;
 }
 
 export interface StockTimesPendingPlayerActions {
@@ -256,6 +276,10 @@ export class TheStockTimesServer
             usedAt: undefined
           },
           loan: {
+            cooldownTime: undefined,
+            usedAt: undefined
+          },
+          lockCashSpending: {
             cooldownTime: undefined,
             usedAt: undefined
           },

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.module.scss
@@ -38,4 +38,8 @@
     &.day {
         background: rgba(vars.$yellow, 0.1);
     }
+
+    &.locked {
+        background: rgba(vars.$red, 0.15);
+    }
 }

--- a/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/cycle/Clock.tsx
@@ -3,6 +3,9 @@ import { StockTimesCycle } from "../../../../backend/theStockTimes/theStockTimes
 import { Flex } from "../../../components";
 import { useCycleTime } from "../../hooks/cycleTime";
 import styles from "./Clock.module.scss";
+import { useGameStateSelector } from "../../store/theStockTimesRedux";
+import { selectPlayerPortfolio } from "../../store/selectors";
+import { isAvailable } from "../../hooks/utils/isAvailable";
 
 const DEFAULT_SIZE = 75;
 
@@ -47,17 +50,28 @@ export const Clock = ({
   cycle: StockTimesCycle;
   size?: number;
 }) => {
+  const lockCashSpending = useGameStateSelector(
+    selectPlayerPortfolio
+  )?.lockCashSpending;
   const calculatedCycleTime = useCycleTime(cycle);
   const finalSize = size ?? DEFAULT_SIZE;
 
   const { day, timeFraction } = calculatedCycleTime;
+  const isLocked = !isAvailable(
+    cycle,
+    lockCashSpending?.lockedAt,
+    lockCashSpending?.availabilityTime
+  ).isAvailable;
 
   return (
     <>
       <Flex
         className={clsx(styles.background, {
-          [styles.day ?? ""]: calculatedCycleTime.currentCycle === "day",
-          [styles.night ?? ""]: calculatedCycleTime.currentCycle === "night"
+          [styles.day ?? ""]:
+            calculatedCycleTime.currentCycle === "day" && !isLocked,
+          [styles.night ?? ""]:
+            calculatedCycleTime.currentCycle === "night" && !isLocked,
+          [styles.locked ?? ""]: isLocked
         })}
       />
       <Flex align="center" gap="1">

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/CashLock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/CashLock.tsx
@@ -1,0 +1,104 @@
+import { PlayerId } from "@resync-games/api";
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { useState } from "react";
+import { Flex, Select, Text } from "../../../components";
+import { selectOpponents, selectPlayerPortfolio } from "../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { ActivateStorePower } from "../store/ActivateStorePower";
+
+export const CASH_LOCK_DURATION = 0.75;
+export const CASH_LOCK_COOLDOWN = 3.5;
+
+export const CashLock = () => {
+  const dispatch = useGameStateDispatch();
+
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const pendingPlayerActions = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.pendingPlayerActions
+  );
+
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+  const opponents = useGameStateSelector(selectOpponents);
+
+  const [playerSelector, setPlayerSelector] = useState(opponents[0]?.playerId);
+
+  if (playerPortfolio === undefined || opponents.length === 0) {
+    return <Text color="gray">No opponents available</Text>;
+  }
+
+  const lockPlayerCash = () => {
+    if (
+      player === undefined ||
+      cycle === undefined ||
+      playerSelector === undefined ||
+      pendingPlayerActions?.[playerSelector]?.lockCashSpending !== undefined
+    ) {
+      return;
+    }
+
+    const totalDuration =
+      (cycle.dayTime + cycle.nightTime) * CASH_LOCK_DURATION;
+    const cashLockCooldown =
+      (cycle.dayTime + cycle.nightTime) * CASH_LOCK_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          pendingPlayerActions: {
+            [playerSelector]: {
+              lastUpdatedAt: new Date().toISOString(),
+              lockCashSpending: {
+                availabilityTime: totalDuration,
+                lockedAt: usedAt
+              }
+            }
+          },
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              lastUpdatedAt: new Date().toISOString(),
+              storePowers: {
+                ...playerPortfolio.storePowers,
+                lockCashSpending: {
+                  cooldownTime: cashLockCooldown,
+                  usedAt
+                }
+              }
+            }
+          }
+        },
+        player
+      )
+    );
+
+    setPlayerSelector(undefined);
+  };
+
+  return (
+    <Flex align="center" flex="1" gap="2">
+      <Flex flex="1">
+        <Select<PlayerId>
+          items={opponents.map((player) => ({
+            label: player.displayName,
+            value: player.playerId
+          }))}
+          onChange={setPlayerSelector}
+          value={playerSelector}
+        />
+      </Flex>
+      <Flex flex="1">
+        <ActivateStorePower
+          disabled={playerSelector === undefined || playerSelector === ""}
+          onClick={lockPlayerCash}
+          storePower="lockCashSpending"
+        />
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.tsx
@@ -1,4 +1,5 @@
 import { Flex, Text } from "../../../components";
+import { CASH_LOCK_DURATION, CASH_LOCK_COOLDOWN, CashLock } from "./CashLock";
 import { CORRUPT_STOCK_COOLDOWN, CorruptStock } from "./CorruptStock";
 import styles from "./Sabotage.module.scss";
 
@@ -25,6 +26,29 @@ export const Sabotage = () => {
           <Flex justify="end">
             <Text color="gray" size="2">
               {CORRUPT_STOCK_COOLDOWN} day cooldown
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex className={styles.sabotagePower} direction="column">
+        <Flex align="center" className={styles.powerName} p="2">
+          <Flex flex="1">
+            <Text size="4" weight="bold">
+              Cash lock
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex direction="column" gap="1" p="2">
+          <Text color="gray" size="2">
+            Prevents a player from spending their cash for {CASH_LOCK_DURATION}{" "}
+            days. Use this to prevent a player from purchasing stock.
+          </Text>
+          <Flex py="2">
+            <CashLock />
+          </Flex>
+          <Flex justify="end">
+            <Text color="gray" size="2">
+              {CASH_LOCK_COOLDOWN} day cooldown
             </Text>
           </Flex>
         </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/store/powers/TransferCash.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/powers/TransferCash.tsx
@@ -3,7 +3,10 @@ import { PlayerId } from "@resync-games/api";
 import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 import { useState } from "react";
 import { Button, Flex, Select, Text, TextField } from "../../../../components";
-import { selectPlayerPortfolio, selectTeams } from "../../../store/selectors";
+import {
+  selectPlayerPortfolio,
+  selectTeammates
+} from "../../../store/selectors";
 import {
   updateTheStockTimesGameState,
   useGameStateDispatch,
@@ -23,19 +26,14 @@ export const TransferCash = () => {
   );
 
   const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
-  const teams = useGameStateSelector(selectTeams);
-
-  const playersOnTeam = teams[playerPortfolio?.team ?? ""]?.players ?? [];
-  const filteredPlayers = playersOnTeam.filter(
-    (p) => p.playerId !== player?.playerId
-  );
+  const teammates = useGameStateSelector(selectTeammates);
 
   const [playerSelector, setPlayerSelector] = useState<PlayerId | undefined>(
-    filteredPlayers[0]?.playerId
+    teammates[0]?.playerId
   );
   const [cashSelector, setCashSelector] = useState<string>("0");
 
-  if (playerPortfolio === undefined || filteredPlayers.length === 0) {
+  if (playerPortfolio === undefined || teammates.length === 0) {
     return <Text color="gray">No teammates available</Text>;
   }
 
@@ -108,7 +106,7 @@ export const TransferCash = () => {
   return (
     <Flex direction="column" flex="1" gap="2">
       <Select<PlayerId>
-        items={filteredPlayers.map((player) => ({
+        items={teammates.map((player) => ({
           label: player.displayName,
           value: player.playerId
         }))}

--- a/packages/games/src/frontend/theStockTimes/hooks/cashSpendLock.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/cashSpendLock.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { selectPlayerPortfolio } from "../store/selectors";
+import { useGameStateSelector } from "../store/theStockTimesRedux";
+import { isAvailable, IsAvailable } from "./utils/isAvailable";
+
+export function useCashSpendLock(): IsAvailable {
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const cashSpendLock = useGameStateSelector(
+    selectPlayerPortfolio
+  )?.lockCashSpending;
+
+  const [_, setCounter] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCounter((prev) => prev + 1);
+    }, 100);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (cycle === undefined || cashSpendLock === undefined) {
+    return {
+      isAvailable: true,
+      timeLeft: 0
+    };
+  }
+
+  return isAvailable(
+    cycle,
+    cashSpendLock?.lockedAt,
+    cashSpendLock?.availabilityTime
+  );
+}

--- a/packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts
@@ -59,6 +59,15 @@ export function usePendingPlayerChanges() {
       newPlayerActions.lastUpdatedAt = new Date().toISOString();
     }
 
+    if (pendingPlayerActions.lockCashSpending !== undefined) {
+      newPlayerPortfolio.lockCashSpending =
+        pendingPlayerActions.lockCashSpending;
+      newPlayerPortfolio.lastUpdatedAt = new Date().toISOString();
+
+      newPlayerActions.lockCashSpending = undefined;
+      newPlayerActions.lastUpdatedAt = new Date().toISOString();
+    }
+
     processActionsAndPortfolio(newPlayerPortfolio, newPlayerActions);
   }, [pendingPlayerActions?.lastUpdatedAt]);
 }

--- a/packages/games/src/frontend/theStockTimes/store/selectors.ts
+++ b/packages/games/src/frontend/theStockTimes/store/selectors.ts
@@ -50,6 +50,28 @@ export const selectTeams = createSelector(
   }
 );
 
+export const selectTeammates = createSelector(
+  [
+    selectTeams,
+    selectPlayerPortfolio,
+    (state: TheStockTimesReduxState) => state.playerSlice.player
+  ],
+  (teams, playerPortfolio, player) => {
+    const teammates = teams[playerPortfolio?.team ?? 0]?.players ?? [];
+    return teammates.filter((p) => p.playerId !== player?.playerId);
+  }
+);
+
+export const selectOpponents = createSelector(
+  [selectTeams, selectPlayerPortfolio],
+  (teams, playerPortfolio) => {
+    const opponents = Object.entries(teams).filter(
+      ([teamNumber]) => teamNumber !== playerPortfolio?.team?.toString()
+    );
+    return opponents.flatMap(([_teamNumber, { players }]) => players);
+  }
+);
+
 export const selectTotalTeamValue = createSelector(
   [
     (state: TheStockTimesReduxState) => state.gameStateSlice.gameInfo?.players,


### PR DESCRIPTION
<img width="698" alt="Screenshot 2025-01-07 at 10 25 45 PM" src="https://github.com/user-attachments/assets/d9418770-a93c-42dc-bee8-d87b09ab9576" />

---

This pull request introduces a new feature to lock a player's cash spending in the game "The Stock Times". The changes include updates to both the backend and frontend components to support this feature.

### Backend Changes:
* Added `lockCashSpending` attribute to `StockTimesPlayer` and `StockTimesPlayerActions` interfaces to handle the cash lock state. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R100-R103) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R126-R129) [[3]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R166-R179)
* Updated `TheStockTimesServer` class to initialize the `lockCashSpending` state.

### Frontend Changes:
* Modified `Clock.module.scss` to include a new style for the locked state.
* Updated `Clock.tsx` to display the locked state based on the `lockCashSpending` attribute. [[1]](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eR6-R8) [[2]](diffhunk://#diff-fc2440980b29326524a0438fe20654fd56102842400141899256e02dab208e0eR53-R74)
* Introduced `CashLock` component to handle the cash lock functionality and its integration into the `Sabotage` component. [[1]](diffhunk://#diff-3404c716698883cc325d336fd38b25f22f3c6121cf455b61e337143ab70266c3R1-R104) [[2]](diffhunk://#diff-e91262c98147ab82f37d854cbf2bc8de83b09d829e09426e0994cb2ee0201f03R2) [[3]](diffhunk://#diff-e91262c98147ab82f37d854cbf2bc8de83b09d829e09426e0994cb2ee0201f03R33-R55)
* Enhanced `PurchaseStock.tsx` to disable stock purchasing when cash spending is locked and display a progress bar indicating the remaining lock time. [[1]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396L7-R7) [[2]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396R18) [[3]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396R30-R31) [[4]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396R211-R240) [[5]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396L242-R275)
* Updated `TransferCash.tsx` to use the `selectTeammates` selector for better teammate selection logic. [[1]](diffhunk://#diff-4a9bea33849d6be3cb6f4a2a246c1fc369fed5aeec8303a6b74e6ad434cfb47cL6-R9) [[2]](diffhunk://#diff-4a9bea33849d6be3cb6f4a2a246c1fc369fed5aeec8303a6b74e6ad434cfb47cL26-R36) [[3]](diffhunk://#diff-4a9bea33849d6be3cb6f4a2a246c1fc369fed5aeec8303a6b74e6ad434cfb47cL111-R109)

### New Hooks and Selectors:
* Added `useCashSpendLock` hook to manage the cash lock state and provide availability status and time left.
* Updated `usePendingPlayerChanges` to process `lockCashSpending` actions.
* Introduced `selectTeammates` and `selectOpponents` selectors to streamline player selection logic.