### PR TITLE
Add stock lock sabotage option

### DIFF
--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -108,6 +108,12 @@ export interface StockTimesPlayer extends WithTimestamp {
     [stockSymbol: string]: OwnedStock[];
   };
   /**
+   * Prevents the player from selling the stock.
+   */
+  stockLocks: {
+    [stockSymbol: string]: PowerLock;
+  };
+  /**
    * The store powers the player has. This will be used to determine if the player can use a power.
    */
   storePowers: {
@@ -131,6 +137,10 @@ export interface StockTimesPlayer extends WithTimestamp {
      * Converts the losses on a holding into gains.
      */
     lossIntoGain: StorePowerUpUsage;
+    /**
+     * Prevents a player from selling a stock for a set amount of time.
+     */
+    stockLock: StorePowerUpUsage;
     /**
      * Allows the player to transfer cash to another player, on their team.
      */
@@ -177,6 +187,10 @@ export interface PowerLock {
 export interface StockTimesPlayerActions extends WithTimestamp {
   cashInflux?: number;
   lockCashSpending?: PowerLock;
+  stockLock?: {
+    lock: PowerLock;
+    stockSymbol: string;
+  };
 }
 
 export interface StockTimesPendingPlayerActions {
@@ -266,6 +280,7 @@ export class TheStockTimesServer
         debt: 0,
         lastUpdatedAt: new Date().toISOString(),
         ownedStocks: {},
+        stockLocks: {},
         storePowers: {
           corruptedStock: {
             cooldownTime: undefined,
@@ -284,6 +299,10 @@ export class TheStockTimesServer
             usedAt: undefined
           },
           lossIntoGain: {
+            cooldownTime: undefined,
+            usedAt: undefined
+          },
+          stockLock: {
             cooldownTime: undefined,
             usedAt: undefined
           },

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerPortfolio.tsx
@@ -108,7 +108,7 @@ export const PlayerPortfolio = () => {
           <Tabs.Trigger value="sabotage">Sabotage</Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="your-portfolio">
-          <Flex direction="column" mt="2">
+          <Flex direction="column" gap="2" mt="2">
             {renderYourPortfolio()}
             <PlayerStocks />
           </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
@@ -31,101 +31,107 @@ export const PlayerStocks = () => {
     );
   };
 
-  return playerStocksSorted.map((symbol) => {
-    const ownedStock = playerPortfolio.ownedStocks[symbol];
-    if (ownedStock === undefined || ownedStock.length === 0) {
-      return;
-    }
+  return (
+    <Flex direction="column" gap="3">
+      {playerStocksSorted.map((symbol) => {
+        const ownedStock = playerPortfolio.ownedStocks[symbol];
+        if (ownedStock === undefined || ownedStock.length === 0) {
+          return;
+        }
 
-    const stock = stocks?.[symbol];
+        const stock = stocks?.[symbol];
 
-    const currentPrice = stock?.history[0]?.price ?? 0;
-    const totalQuantity = ownedStock.reduce(
-      (previous, next) => previous + next.quantity,
-      0
-    );
-    const totalPrice = totalQuantity * currentPrice;
+        const currentPrice = stock?.history[0]?.price ?? 0;
+        const totalQuantity = ownedStock.reduce(
+          (previous, next) => previous + next.quantity,
+          0
+        );
+        const totalPrice = totalQuantity * currentPrice;
 
-    const sortedQuantity = ownedStock
-      .slice()
-      .sort((a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf());
+        const sortedQuantity = ownedStock
+          .slice()
+          .sort(
+            (a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf()
+          );
 
-    return (
-      <Flex direction="column" key={symbol}>
-        <Flex
-          align="center"
-          className={styles.stockSymbol}
-          gap="3"
-          onClick={setViewingStockSymbol(symbol)}
-        >
-          <Text>{symbol}</Text>
-          <Flex className={styles.divider} flex="1" />
-          <Text color="green">{displayDollar(totalPrice)}</Text>
-        </Flex>
-        <Flex direction="column" gap="4" ml="3" mt="2">
-          {sortedQuantity.map((ownedStock, index) => {
-            const { price, quantity } = ownedStock;
-            const costBasis = price * quantity;
-            const revenue = currentPrice * quantity;
-            const totalProfit = revenue - costBasis;
+        return (
+          <Flex direction="column" key={symbol}>
+            <Flex
+              align="center"
+              className={styles.stockSymbol}
+              gap="3"
+              onClick={setViewingStockSymbol(symbol)}
+            >
+              <Text>{symbol}</Text>
+              <Flex className={styles.divider} flex="1" />
+              <Text color="green">{displayDollar(totalPrice)}</Text>
+            </Flex>
+            <Flex direction="column" gap="4" ml="3" mt="2">
+              {sortedQuantity.map((ownedStock, index) => {
+                const { price, quantity } = ownedStock;
+                const costBasis = price * quantity;
+                const revenue = currentPrice * quantity;
+                const totalProfit = revenue - costBasis;
 
-            return (
-              <Flex
-                className={styles.holding}
-                direction="column"
-                gap="1"
-                key={`${symbol}-${index}`}
-              >
-                <Flex
-                  align="center"
-                  className={styles.holdingAction}
-                  gap="4"
-                  justify="between"
-                  p="2"
-                >
-                  <Flex align="center" gap="2">
-                    <Flex>
-                      <Text>{quantity.toLocaleString()}</Text>
+                return (
+                  <Flex
+                    className={styles.holding}
+                    direction="column"
+                    gap="1"
+                    key={`${symbol}-${index}`}
+                  >
+                    <Flex
+                      align="center"
+                      className={styles.holdingAction}
+                      gap="4"
+                      justify="between"
+                      p="2"
+                    >
+                      <Flex align="center" gap="2">
+                        <Flex>
+                          <Text>{quantity.toLocaleString()}</Text>
+                        </Flex>
+                        <Text color="gray" size="2">
+                          at
+                        </Text>
+                        <Text color="green">{displayDollar(price)}</Text>
+                      </Flex>
+                      <Flex width="50%">
+                        <SellPlayerStock
+                          atLoss={totalProfit < 0}
+                          currentPrice={currentPrice}
+                          ownedStock={ownedStock}
+                          symbol={symbol}
+                        />
+                      </Flex>
                     </Flex>
-                    <Text color="gray" size="2">
-                      at
-                    </Text>
-                    <Text color="green">{displayDollar(price)}</Text>
+                    <Flex align="center" gap="1" px="2" py="1" wrap="wrap">
+                      <Text color="green">{displayDollar(revenue)}</Text>
+                      <Text color="gray" size="2">
+                        (revenue)
+                      </Text>
+                      <Text>-</Text>
+                      <Text color="red">{displayDollar(costBasis)}</Text>
+                      <Text color="gray" size="2">
+                        (cost basis)
+                      </Text>
+                    </Flex>
+                    <Flex align="center" gap="1" px="2" py="1" wrap="wrap">
+                      <Text>=</Text>
+                      <Text color={totalProfit > 0 ? "green" : "red"} size="4">
+                        {displayDollar(totalProfit)}
+                      </Text>
+                      <Text color="gray" size="2">
+                        (profit)
+                      </Text>
+                    </Flex>
                   </Flex>
-                  <Flex width="50%">
-                    <SellPlayerStock
-                      atLoss={totalProfit < 0}
-                      currentPrice={currentPrice}
-                      ownedStock={ownedStock}
-                      symbol={symbol}
-                    />
-                  </Flex>
-                </Flex>
-                <Flex align="center" gap="1" px="2" py="1" wrap="wrap">
-                  <Text color="green">{displayDollar(revenue)}</Text>
-                  <Text color="gray" size="2">
-                    (revenue)
-                  </Text>
-                  <Text>-</Text>
-                  <Text color="red">{displayDollar(costBasis)}</Text>
-                  <Text color="gray" size="2">
-                    (cost basis)
-                  </Text>
-                </Flex>
-                <Flex align="center" gap="1" px="2" py="1" wrap="wrap">
-                  <Text>=</Text>
-                  <Text color={totalProfit > 0 ? "green" : "red"} size="4">
-                    {displayDollar(totalProfit)}
-                  </Text>
-                  <Text color="gray" size="2">
-                    (profit)
-                  </Text>
-                </Flex>
-              </Flex>
-            );
-          })}
-        </Flex>
-      </Flex>
-    );
-  });
+                );
+              })}
+            </Flex>
+          </Flex>
+        );
+      })}
+    </Flex>
+  );
 };

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
@@ -31,7 +31,7 @@ export const SellPlayerStock = ({
   const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
   const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
 
-  const { isAvailable, timeLeft } = useStockLock(ownedStock);
+  const { isAvailable, timeLeft } = useStockLock(ownedStock, symbol);
 
   const removeStock = () => {
     if (playerPortfolio === undefined) {
@@ -151,7 +151,7 @@ export const SellPlayerStock = ({
     return (
       <Flex align="center" flex="1" gap="2">
         <Text color="gray">Locked</Text>
-        <Progress color="blue" value={timeLeft} />
+        <Progress color="red" value={timeLeft} />
       </Flex>
     );
   }

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/CashLock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/CashLock.tsx
@@ -81,24 +81,20 @@ export const CashLock = () => {
   };
 
   return (
-    <Flex align="center" flex="1" gap="2">
-      <Flex flex="1">
-        <Select<PlayerId>
-          items={opponents.map((player) => ({
-            label: player.displayName,
-            value: player.playerId
-          }))}
-          onChange={setPlayerSelector}
-          value={playerSelector}
-        />
-      </Flex>
-      <Flex flex="1">
-        <ActivateStorePower
-          disabled={playerSelector === undefined || playerSelector === ""}
-          onClick={lockPlayerCash}
-          storePower="lockCashSpending"
-        />
-      </Flex>
+    <Flex direction="column" flex="1" gap="2">
+      <Select<PlayerId>
+        items={opponents.map((player) => ({
+          label: player.displayName,
+          value: player.playerId
+        }))}
+        onChange={setPlayerSelector}
+        value={playerSelector}
+      />
+      <ActivateStorePower
+        disabled={playerSelector === undefined || playerSelector === ""}
+        onClick={lockPlayerCash}
+        storePower="lockCashSpending"
+      />
     </Flex>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/CorruptStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/CorruptStock.tsx
@@ -25,13 +25,13 @@ export const CorruptStock = () => {
     (s) => s.gameStateSlice.gameState?.stocks ?? {}
   );
 
-  const [stockSelector, setStockSelector] = useState("");
-
   const sortedStock = useMemo(() => {
     return Object.entries(stocks).sort(([aSymbol], [bSymbol]) => {
       return aSymbol.localeCompare(bSymbol);
     });
   }, [stocks]);
+
+  const [stockSelector, setStockSelector] = useState(sortedStock[0]?.[0]);
 
   const onCorruptStock = () => {
     if (

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/Sabotage.tsx
@@ -2,6 +2,11 @@ import { Flex, Text } from "../../../components";
 import { CASH_LOCK_DURATION, CASH_LOCK_COOLDOWN, CashLock } from "./CashLock";
 import { CORRUPT_STOCK_COOLDOWN, CorruptStock } from "./CorruptStock";
 import styles from "./Sabotage.module.scss";
+import {
+  STOCK_LOCK_COOLDOWN,
+  STOCK_LOCK_DURATION,
+  StockLock
+} from "./StockLock";
 
 export const Sabotage = () => {
   return (
@@ -49,6 +54,30 @@ export const Sabotage = () => {
           <Flex justify="end">
             <Text color="gray" size="2">
               {CASH_LOCK_COOLDOWN} day cooldown
+            </Text>
+          </Flex>
+        </Flex>
+      </Flex>
+      <Flex className={styles.sabotagePower} direction="column">
+        <Flex align="center" className={styles.powerName} p="2">
+          <Flex flex="1">
+            <Text size="4" weight="bold">
+              Stock lock
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex direction="column" gap="1" p="2">
+          <Text color="gray" size="2">
+            Prevents a player from selling a specific stock for{" "}
+            {STOCK_LOCK_DURATION} days. Use this to prevent a player from
+            selling a specific stock.
+          </Text>
+          <Flex py="2">
+            <StockLock />
+          </Flex>
+          <Flex justify="end">
+            <Text color="gray" size="2">
+              {STOCK_LOCK_COOLDOWN} day cooldown
             </Text>
           </Flex>
         </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/sabotage/StockLock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/sabotage/StockLock.tsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from "react";
+import { selectOpponents, selectPlayerPortfolio } from "../../store/selectors";
+import {
+  updateTheStockTimesGameState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
+import { Flex, Select, Text } from "../../../components";
+import { ActivateStorePower } from "../store/ActivateStorePower";
+import { PlayerId } from "@resync-games/api";
+
+export const STOCK_LOCK_DURATION = 0.75;
+export const STOCK_LOCK_COOLDOWN = 1.5;
+
+export const StockLock = () => {
+  const dispatch = useGameStateDispatch();
+
+  const player = useGameStateSelector((s) => s.playerSlice.player);
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const pendingPlayerActions = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.pendingPlayerActions
+  );
+
+  const playerPortfolio = useGameStateSelector(selectPlayerPortfolio);
+  const opponents = useGameStateSelector(selectOpponents);
+  const stocks = useGameStateSelector(
+    (s) => s.gameStateSlice.gameState?.stocks ?? {}
+  );
+
+  const sortedStock = useMemo(() => {
+    return Object.entries(stocks).sort(([aSymbol], [bSymbol]) => {
+      return aSymbol.localeCompare(bSymbol);
+    });
+  }, [stocks]);
+
+  const [playerSelector, setPlayerSelector] = useState(opponents[0]?.playerId);
+  const [stockSelector, setStockSelector] = useState(sortedStock[0]?.[0]);
+
+  if (playerPortfolio === undefined || opponents.length === 0) {
+    return <Text color="gray">No opponents available</Text>;
+  }
+
+  const lockPlayerStock = () => {
+    if (
+      player === undefined ||
+      cycle === undefined ||
+      playerSelector === undefined ||
+      stockSelector === undefined ||
+      pendingPlayerActions?.[playerSelector]?.stockLock !== undefined
+    ) {
+      return;
+    }
+
+    const totalDuration =
+      (cycle.dayTime + cycle.nightTime) * STOCK_LOCK_DURATION;
+    const stockLockCooldown =
+      (cycle.dayTime + cycle.nightTime) * STOCK_LOCK_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
+
+    dispatch(
+      updateTheStockTimesGameState(
+        {
+          pendingPlayerActions: {
+            [playerSelector]: {
+              lastUpdatedAt: new Date().toISOString(),
+              stockLock: {
+                lock: {
+                  availabilityTime: totalDuration,
+                  lockedAt: usedAt
+                },
+                stockSymbol: stockSelector
+              }
+            }
+          },
+          players: {
+            [player.playerId]: {
+              ...playerPortfolio,
+              lastUpdatedAt: new Date().toISOString(),
+              storePowers: {
+                ...playerPortfolio.storePowers,
+                stockLock: {
+                  cooldownTime: stockLockCooldown,
+                  usedAt
+                }
+              }
+            }
+          }
+        },
+        player
+      )
+    );
+
+    setPlayerSelector(undefined);
+  };
+
+  return (
+    <Flex direction="column" flex="1" gap="2">
+      <Flex align="center" gap="2">
+        <Text color="gray" size="2">
+          Player
+        </Text>
+        <Select<PlayerId>
+          items={opponents.map((player) => ({
+            label: player.displayName,
+            value: player.playerId
+          }))}
+          onChange={setPlayerSelector}
+          value={playerSelector}
+        />
+      </Flex>
+      <Flex align="center" gap="2">
+        <Text color="gray" size="2">
+          Stock
+        </Text>
+        <Select
+          items={sortedStock.map(([symbol, stock]) => ({
+            label: `[${symbol}] ${stock.title}`,
+            value: symbol
+          }))}
+          onChange={setStockSelector}
+          value={stockSelector}
+        />
+      </Flex>
+      <ActivateStorePower
+        disabled={
+          stockSelector === undefined ||
+          stockSelector === "" ||
+          playerSelector === undefined ||
+          playerSelector === ""
+        }
+        onClick={lockPlayerStock}
+        storePower="stockLock"
+      />
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
@@ -213,7 +213,7 @@ export const PurchaseStock = ({
       return (
         <Flex align="center" flex="1" gap="2">
           <Text color="gray">Locked</Text>
-          <Progress color="blue" value={timeLeft} />
+          <Progress color="red" value={timeLeft} />
         </Flex>
       );
     }

--- a/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/store/StockTimesStore.tsx
@@ -141,8 +141,11 @@ export const StockTimesStore = () => {
         </Flex>
         <Flex direction="column" gap="1" p="2">
           <Text color="gray" size="2">
-            Converts losses into gains for 1 holding. Activate this on a holding
-            with losses in the "your portfolio" section.
+            Converts losses into gains for 1 holding. In other words, if you
+            have a <Text color="red">$100.00</Text> in losses, this power will
+            convert it to a <Text color="green">$100.00</Text> in gains.
+            Activate this on a holding with losses in the "your portfolio"
+            section.
           </Text>
           <Flex justify="end">
             <Text color="gray" size="2">

--- a/packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/pendingPlayerChanges.ts
@@ -10,6 +10,7 @@ import {
   StockTimesPendingPlayerActions,
   StockTimesPlayer
 } from "../../../backend/theStockTimes/theStockTimes";
+import { cloneDeep } from "lodash";
 
 export function usePendingPlayerChanges() {
   const dispatch = useGameStateDispatch();
@@ -49,8 +50,11 @@ export function usePendingPlayerChanges() {
       return;
     }
 
+    // TODO: display a toast when these activate
+
     const newPlayerActions = { ...pendingPlayerActions };
-    const newPlayerPortfolio = { ...playerPortfolio };
+    const newPlayerPortfolio = cloneDeep(playerPortfolio);
+
     if (pendingPlayerActions.cashInflux !== undefined) {
       newPlayerPortfolio.cash += pendingPlayerActions.cashInflux;
       newPlayerPortfolio.lastUpdatedAt = new Date().toISOString();
@@ -65,6 +69,16 @@ export function usePendingPlayerChanges() {
       newPlayerPortfolio.lastUpdatedAt = new Date().toISOString();
 
       newPlayerActions.lockCashSpending = undefined;
+      newPlayerActions.lastUpdatedAt = new Date().toISOString();
+    }
+
+    if (pendingPlayerActions.stockLock !== undefined) {
+      newPlayerPortfolio.stockLocks[
+        pendingPlayerActions.stockLock.stockSymbol
+      ] = pendingPlayerActions.stockLock.lock;
+      newPlayerPortfolio.lastUpdatedAt = new Date().toISOString();
+
+      newPlayerActions.stockLock = undefined;
       newPlayerActions.lastUpdatedAt = new Date().toISOString();
     }
 

--- a/packages/games/src/frontend/theStockTimes/hooks/stockLock.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/stockLock.ts
@@ -1,10 +1,16 @@
 import { useEffect, useState } from "react";
 import { OwnedStock } from "../../../backend/theStockTimes/theStockTimes";
+import { selectPlayerPortfolio } from "../store/selectors";
 import { useGameStateSelector } from "../store/theStockTimesRedux";
 import { isAvailable, IsAvailable } from "./utils/isAvailable";
 
-export function useStockLock(ownedStock: OwnedStock): IsAvailable {
+export function useStockLock(
+  ownedStock: OwnedStock,
+  stockSymbol: string
+): IsAvailable {
   const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const maybeStockLock = useGameStateSelector(selectPlayerPortfolio)
+    ?.stockLocks[stockSymbol];
 
   const [_, setCounter] = useState(0);
 
@@ -18,16 +24,31 @@ export function useStockLock(ownedStock: OwnedStock): IsAvailable {
     };
   }, []);
 
-  if (cycle === undefined || ownedStock.lockedUntil === undefined) {
+  if (cycle === undefined) {
     return {
       isAvailable: true,
       timeLeft: 0
     };
   }
 
-  return isAvailable(
+  const availableLockedUntil = isAvailable(
     cycle,
     ownedStock.lockedUntil?.lockedAt,
     ownedStock.lockedUntil?.availabilityTime
   );
+
+  const availableStockLock = isAvailable(
+    cycle,
+    maybeStockLock?.lockedAt,
+    maybeStockLock?.availabilityTime
+  );
+
+  return {
+    isAvailable:
+      availableLockedUntil.isAvailable && availableStockLock.isAvailable,
+    timeLeft: Math.max(
+      availableLockedUntil.timeLeft,
+      availableStockLock.timeLeft
+    )
+  };
 }

--- a/packages/games/src/frontend/theStockTimes/store/selectors.ts
+++ b/packages/games/src/frontend/theStockTimes/store/selectors.ts
@@ -77,9 +77,11 @@ export const selectTotalTeamValue = createSelector(
     (state: TheStockTimesReduxState) => state.gameStateSlice.gameInfo?.players,
     (state: TheStockTimesReduxState) => state.gameStateSlice.gameState?.players,
     (state: TheStockTimesReduxState) => state.gameStateSlice.gameState?.stocks,
-    selectTeams
+    selectTeams,
+    (state: TheStockTimesReduxState) =>
+      state.gameStateSlice.gameState?.pendingPlayerActions
   ],
-  (players, gamePlayers, stocks, existingTeams) => {
+  (players, gamePlayers, stocks, existingTeams, pendingPlayerActions) => {
     const teams: {
       [teamNumber: number]: { averageTeamValue: number; totalPlayers: number };
     } = {};
@@ -94,8 +96,10 @@ export const selectTotalTeamValue = createSelector(
           (acc, stock) => acc + stock.quantity * latestPrice,
           0
         );
+        const pendingCashInflux =
+          pendingPlayerActions?.[player.playerId]?.cashInflux ?? 0;
 
-        return previous + totalValue;
+        return previous + totalValue + pendingCashInflux;
       }, 0);
 
       teams[player.team ?? 0] = {


### PR DESCRIPTION
<img width="351" alt="Screenshot 2025-01-07 at 11 00 14 PM" src="https://github.com/user-attachments/assets/f470f9ff-6b59-4577-aa94-6fc9950655c8" />
<img width="390" alt="Screenshot 2025-01-07 at 11 00 27 PM" src="https://github.com/user-attachments/assets/44512d81-1475-4cdf-a2dd-4cb6f97e8bfe" />

---

This pull request introduces a new feature to the `TheStockTimes` game, which allows players to lock stocks, preventing them from being sold for a certain period. This includes backend changes to support the new feature and frontend updates to integrate it into the user interface.

Backend changes:

* Added `stockLocks` property to `StockTimesPlayer` interface to manage stock locks for players.
* Introduced `stockLock` property in `PowerLock` interface to handle stock lock actions.
* Updated `TheStockTimesServer` class to initialize `stockLocks` and `stockLock` properties. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R283) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R305-R308)

Frontend changes:

* Added `StockLock` component to allow players to lock stocks of opponents.
* Updated `PlayerPortfolio`, `PlayerStocks`, and `SellPlayerStock` components to display stock lock status and integrate the new feature. [[1]](diffhunk://#diff-22e8c033c57eea385c789227eaf5fb735894aad99d681ea6a0bbc9a4f5a732b3L111-R111) [[2]](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeL34-R36) [[3]](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeL51-R55) [[4]](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeL130-R136) [[5]](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09L34-R34) [[6]](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09L154-R154)
* Modified `Sabotage` component to include the new `StockLock` power. [[1]](diffhunk://#diff-e91262c98147ab82f37d854cbf2bc8de83b09d829e09426e0994cb2ee0201f03R5-R9) [[2]](diffhunk://#diff-e91262c98147ab82f37d854cbf2bc8de83b09d829e09426e0994cb2ee0201f03R61-R84)

Additional changes:

* Updated `usePendingPlayerChanges` hook to process stock lock actions. [[1]](diffhunk://#diff-0bbe6b7430d9f70b975bf03067bd98bcb956366fa1f39b3e492b35d0f29639b4R53-R57) [[2]](diffhunk://#diff-0bbe6b7430d9f70b975bf03067bd98bcb956366fa1f39b3e492b35d0f29639b4R75-R84)
* Enhanced `useStockLock` hook to consider stock locks when determining availability. [[1]](diffhunk://#diff-640b9939cb8725db0763e1451fdfac052ebc6849f9982325e1bc51f16f2a7691R3-R13) [[2]](diffhunk://#diff-640b9939cb8725db0763e1451fdfac052ebc6849f9982325e1bc51f16f2a7691L21-R53)

These changes collectively introduce the ability to lock stocks, enhancing the strategic depth of the game.