### PR TITLE
Implement stock times global screen end game graph

### DIFF
--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -69,6 +69,10 @@ export interface OwnedStock {
 }
 
 export interface TransactionHistory {
+  /**
+   * The current time on the clock in milliseconds when transaction happened.
+   */
+  clockTime: number;
   date: string;
   lossIntoGain?: boolean;
   price: number;

--- a/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
+++ b/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
@@ -1,6 +1,7 @@
 import { Flex, Text } from "../components";
 import { Clock } from "./components/cycle/Clock";
 import { FinalScoreboard } from "./components/FinalScoreboard";
+import { EndGameGraph } from "./components/globalScreen/EndGameGraph";
 import { useGameStateSelector } from "./store/theStockTimesRedux";
 
 export const StockTimesGlobalScreen = () => {
@@ -19,16 +20,30 @@ export const StockTimesGlobalScreen = () => {
     );
   }
 
+  if (gameInfo?.currentGameState === "waiting") {
+    return (
+      <Flex align="center" flex="1" justify="center">
+        <Text color="gray">Waiting for the game to start</Text>
+      </Flex>
+    );
+  }
+
+  if (gameInfo?.currentGameState === "finished") {
+    return (
+      <Flex flex="1">
+        <EndGameGraph />
+      </Flex>
+    );
+  }
+
   return (
     <Flex flex="1" gap="2">
       <Flex flex="1">
         <FinalScoreboard />
       </Flex>
-      {gameInfo?.currentGameState === "playing" && (
-        <Flex flex="1">
-          <Clock cycle={gameState?.cycle} size={window.innerWidth / 2} />
-        </Flex>
-      )}
+      <Flex flex="1">
+        <Clock cycle={gameState?.cycle} size={window.innerWidth / 2} />
+      </Flex>
     </Flex>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.module.scss
@@ -4,6 +4,19 @@
     border-radius: 3px;
     background: vars.$white;
     border: 1px solid vars.$black;
+    animation: fadeIn 2s ease-in;
+}
+
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+    }
+    75% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
 }
 
 .divider {

--- a/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
@@ -4,9 +4,36 @@ import { selectTotalTeamValue } from "../store/selectors";
 import { useGameStateSelector } from "../store/theStockTimesRedux";
 import { displayDollar } from "../utils/displayDollar";
 import styles from "./FinalScoreboard.module.scss";
+import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 
 export const FinalScoreboard = () => {
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
   const teams = useGameStateSelector(selectTotalTeamValue);
+
+  // When the last day's articles come out, this should trigger
+  const isLastDay = (() => {
+    if (cycle === undefined) {
+      return false;
+    }
+
+    const { day } = cycleTime(cycle);
+    return day === cycle.endDay - 1;
+  })();
+
+  if (isLastDay) {
+    return (
+      <Flex direction="column" flex="1" gap="3" justify="center" px="5">
+        <Flex
+          align="center"
+          className={styles.teamContainer}
+          justify="center"
+          py="4"
+        >
+          <Text color="gray">Last day of trading!</Text>
+        </Flex>
+      </Flex>
+    );
+  }
 
   return (
     <Flex direction="column" flex="1" gap="3" justify="center" px="5">

--- a/packages/games/src/frontend/theStockTimes/components/globalScreen/EndGameGraph.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/globalScreen/EndGameGraph.tsx
@@ -1,0 +1,51 @@
+import { Flex } from "../../../components";
+import { selectEndGameGraph, selectTeams } from "../../store/selectors";
+import { useGameStateSelector } from "../../store/theStockTimesRedux";
+import { MultiTimeSeries } from "../graph/MultiTimeSeries";
+
+export const EndGameGraph = () => {
+  const players = useGameStateSelector(selectEndGameGraph);
+  const teams = useGameStateSelector(selectTeams);
+
+  const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
+
+  const xDates = Object.keys(Object.values(players)[0] ?? {}).map((v) =>
+    parseFloat(v)
+  );
+  const [teamOne, teamTwo] = Object.values(players).map((team) =>
+    Object.values(team ?? {}).map((v) => v)
+  );
+
+  const xAxisCursor = (value: number) => {
+    if (cycle === undefined) {
+      return;
+    }
+
+    const totalTimePerDay = cycle.dayTime + cycle.nightTime;
+
+    const day = Math.floor(value / (cycle.dayTime + cycle.nightTime));
+    const timeFraction = (value % totalTimePerDay) / totalTimePerDay;
+
+    return `Day ${day} at ${Math.round(timeFraction * 100)}%`;
+  };
+
+  const xAxisLabel = (value: number) => {
+    if (cycle === undefined) {
+      return;
+    }
+
+    return Math.floor(value / (cycle.dayTime + cycle.nightTime)).toString();
+  };
+
+  return (
+    <Flex flex="1" mb="4" p="4">
+      <MultiTimeSeries
+        x={xDates}
+        xAxisCursor={xAxisCursor}
+        xAxisLabel={xAxisLabel}
+        y={[teamOne ?? [], teamTwo ?? []]}
+        yLabels={[teams[0]?.teamName ?? "", teams[1]?.teamName ?? ""]}
+      />
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/components/graph/MultiTimeSeries.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/graph/MultiTimeSeries.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from "react";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+import { displayDollar } from "../../utils/displayDollar";
+import React from "react";
+
+export const MultiTimeSeries = ({
+  x,
+  xAxisLabel,
+  xAxisCursor,
+  y,
+  yLabels
+}: {
+  x: number[];
+  xAxisCursor?: (value: number) => string | undefined;
+  xAxisLabel?: (value: number) => string | undefined;
+  y: [number[], number[]];
+  yLabels: [string, string];
+}) => {
+  const chartRef = useRef<uPlot | null>(null);
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (chartContainerRef.current == null) {
+      return;
+    }
+
+    chartRef.current = new uPlot(
+      {
+        axes: [
+          {
+            grid: {
+              show: true
+            },
+            values: (_, values) =>
+              values.map(
+                (value) =>
+                  xAxisLabel?.(value) ??
+                  `${new Date(value).getMinutes().toString().padStart(2, "0")}:${new Date(value).getSeconds().toString().padStart(2, "0")}`
+              )
+          },
+          {
+            size: 75,
+            values: (_, values) => values.map((value) => displayDollar(value))
+          }
+        ],
+        height: chartContainerRef.current.clientHeight,
+        id: "price",
+        series: [
+          {
+            value: (_, value) => {
+              return value == null
+                ? value
+                : (xAxisCursor?.(value) ?? new Date(value).toLocaleString());
+            }
+          },
+          {
+            fill: "rgba(27, 79, 114, 0.5)",
+            label: yLabels[0],
+            show: true,
+            spanGaps: false,
+            stroke: "rgba(23, 32, 42)",
+            value: (_, value) => displayDollar(value),
+            width: 1
+          },
+          {
+            fill: "rgba(244, 208, 63, 0.5)",
+            label: yLabels[1],
+            show: true,
+            spanGaps: false,
+            stroke: "rgba(23, 32, 42)",
+            value: (_, value) => displayDollar(value),
+            width: 1
+          }
+        ],
+        width: chartContainerRef.current.clientWidth
+      },
+      [x, y[0], y[1]],
+      chartContainerRef.current
+    );
+
+    return () => {
+      chartRef.current?.destroy();
+    };
+  }, [chartRef.current]);
+
+  return <div ref={chartContainerRef} style={{ display: "flex", flex: 1 }} />;
+};

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx
@@ -53,13 +53,20 @@ export const SellPlayerStock = ({
   };
 
   const onSell = () => {
-    if (player === undefined || playerPortfolio === undefined) {
+    if (
+      player === undefined ||
+      playerPortfolio === undefined ||
+      cycle === undefined
+    ) {
       return;
     }
 
     const newCash = playerPortfolio.cash + currentPrice * ownedStock.quantity;
 
+    const usedAt = cycleTime(cycle).currentTime;
+
     const newTransaction: TransactionHistory = {
+      clockTime: usedAt,
       date: new Date().toISOString(),
       price: currentPrice,
       quantity: ownedStock.quantity,
@@ -100,10 +107,15 @@ export const SellPlayerStock = ({
       return;
     }
 
+    const lossIntoGainCooldown =
+      (cycle.dayTime + cycle.nightTime) * SELL_INTO_GAIN_COOLDOWN;
+    const usedAt = cycleTime(cycle).currentTime;
+
     const newPrice = (ownedStock.price - currentPrice) * 2 + currentPrice;
     const newCash = playerPortfolio.cash + newPrice * ownedStock.quantity;
 
     const newTransaction: TransactionHistory = {
+      clockTime: usedAt,
       date: new Date().toISOString(),
       lossIntoGain: true,
       price: currentPrice,
@@ -111,10 +123,6 @@ export const SellPlayerStock = ({
       stockSymbol: symbol,
       type: "sell"
     };
-
-    const lossIntoGainCooldown =
-      (cycle.dayTime + cycle.nightTime) * SELL_INTO_GAIN_COOLDOWN;
-    const usedAt = cycleTime(cycle).currentTime;
 
     dispatch(
       updateTheStockTimesGameState(

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx
@@ -49,10 +49,13 @@ export const PurchaseStock = ({
     if (
       playerPortfolio === undefined ||
       player === undefined ||
-      currentStockPrice === undefined
+      currentStockPrice === undefined ||
+      cycle === undefined
     ) {
       return;
     }
+
+    const lockedAt = cycleTime(cycle).currentTime;
 
     const newOwnedStock: OwnedStock = {
       date: new Date().toISOString(),
@@ -60,6 +63,7 @@ export const PurchaseStock = ({
       quantity
     };
     const newTransaction: TransactionHistory = {
+      clockTime: lockedAt,
       date: new Date().toISOString(),
       price: currentStockPrice,
       quantity,
@@ -132,6 +136,7 @@ export const PurchaseStock = ({
       quantity
     };
     const newTransactionOne: TransactionHistory = {
+      clockTime: lockedAt,
       date: new Date().toISOString(),
       price: currentStockPrice,
       quantity,
@@ -149,6 +154,7 @@ export const PurchaseStock = ({
       quantity
     };
     const newTransactionTwo: TransactionHistory = {
+      clockTime: lockedAt,
       date: new Date().toISOString(),
       price: currentStockPrice,
       quantity,
@@ -221,15 +227,15 @@ export const PurchaseStock = ({
     return (
       <Flex direction="column" flex="1" gap="2">
         <Button
-          disabled={
-            quantity <= 0 || leftOverCash < 0 || !areThereEnoughLockUpDays()
-          }
+          disabled={quantity <= 0 || leftOverCash < 0}
           onClick={purchaseStock}
         >
           Buy {quantity} stocks
         </Button>
         <ActivateStorePower
-          disabled={quantity <= 0 || leftOverCash < 0}
+          disabled={
+            quantity <= 0 || leftOverCash < 0 || !areThereEnoughLockUpDays()
+          }
           onClick={purchaseDiscountStock}
           storePower="discountBuy"
           text={`Buy ${quantity * 2} stocks with lock`}

--- a/packages/games/src/frontend/theStockTimes/utils/displayDollar.ts
+++ b/packages/games/src/frontend/theStockTimes/utils/displayDollar.ts
@@ -8,5 +8,9 @@ export function displayDollar(amount: string | number | null | undefined) {
 
   const number =
     typeof amount === "string" ? parseFloat(amount ?? "0") : amount;
+  if (Math.abs(number) > 1000) {
+    return `$${(number / 1000).toLocaleString(undefined, { maximumFractionDigits: 2 })}k`;
+  }
+
   return `$${number.toLocaleString(undefined, { maximumFractionDigits: 2, minimumFractionDigits: 2 })}`;
 }


### PR DESCRIPTION
<img width="1703" alt="Screenshot 2025-01-08 at 12 33 06 AM" src="https://github.com/user-attachments/assets/93713cb1-7bd1-439f-af30-811751f6076d" />

This pull request includes several enhancements and bug fixes for the `theStockTimes` game. The most important changes are related to the addition of a new graph component, updates to the game state handling, and improvements to the user interface.

### Enhancements to Game State and UI:

* [`packages/games/src/backend/theStockTimes/theStockTimes.ts`](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R72-R75): Added `clockTime` to `TransactionHistory` and updated the `endDay` value to 3 in the game cycle configuration. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01R72-R75) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L244-R248)
* [`packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx`](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R4): Introduced new conditions to handle different game states (`waiting`, `finished`) and added the `EndGameGraph` component. [[1]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R4) [[2]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R23-L31)
* [`packages/games/src/frontend/theStockTimes/components/FinalScoreboard.module.scss`](diffhunk://#diff-040e174b98b04b12b7502e84329e399b84fa2800e4fd240a12e2c65c0e72a68aR7-R19): Added a fade-in animation to enhance the visual appeal of the Final Scoreboard.
* [`packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx`](diffhunk://#diff-f2bb0f2c95ad68730044318df7d89d24de7d461d429283dcafe0402341b62d9cR7-R37): Introduced logic to display a message on the last day of trading.

### New Graph Component:

* [`packages/games/src/frontend/theStockTimes/components/globalScreen/EndGameGraph.tsx`](diffhunk://#diff-4ebfedd2a90e095e2842ef2311e3e924dd9dcf917cb9e2f16acfd6ebedb2efc7R1-R51): Created a new `EndGameGraph` component to display the end game graph.
* [`packages/games/src/frontend/theStockTimes/components/graph/MultiTimeSeries.tsx`](diffhunk://#diff-13a979aa5d95b13b1176fb700ea80c73b2df8561e08ab78da88a97c9859f44f1R1-R88): Added the `MultiTimeSeries` component for rendering time series data using `uPlot`.

### Transaction Handling Improvements:

* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/SellPlayerStock.tsx`](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09L56-R69): Updated transaction handling to include `clockTime` and improved condition checks. [[1]](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09L56-R69) [[2]](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09R110-R118) [[3]](diffhunk://#diff-5921d8607c04718c6d83b104b3078b12432f4ee44fa3ff902f3b58f8f2d4fe09L115-L118)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/PurchaseStock.tsx`](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396L52-R66): Added `clockTime` to transactions and adjusted the button disable logic. [[1]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396L52-R66) [[2]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396R139) [[3]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396R157) [[4]](diffhunk://#diff-457bb32126270950fa0d051ee32553d0b3ca5f1b720a8952cca34fb7ace11396L224-R238)

### Selector and Utility Updates:

* [`packages/games/src/frontend/theStockTimes/store/selectors.ts`](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0R5): Added a new selector `selectEndGameGraph` to compute data for the end game graph. [[1]](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0R5) [[2]](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0R146-R222)
* [`packages/games/src/frontend/theStockTimes/utils/displayDollar.ts`](diffhunk://#diff-e84691df10c3b356d0e3c201e7f543b53ec9d2f710107662a2ba5981ce973586R11-R14): Enhanced `displayDollar` utility to format large numbers in thousands (e.g., `1000` as `1k`).