### PR TITLE
Fix parsing the number field

### DIFF
--- a/packages/frontend/src/components/inGame/components/ConfigureGame.tsx
+++ b/packages/frontend/src/components/inGame/components/ConfigureGame.tsx
@@ -65,7 +65,7 @@ export const ConfigureGame = () => {
           onChange={(newValue) =>
             setCurrentGameConfiguration({
               ...currentGameConfiguration,
-              [key]: newValue
+              [key]: parseFloat(newValue)
             })
           }
           value={currentValue?.toString() ?? ""}


### PR DESCRIPTION
This pull request includes a small change to the `ConfigureGame` component in the `ConfigureGame.tsx` file. The change ensures that the new value is parsed as a float before being set in the game configuration.

* [`packages/frontend/src/components/inGame/components/ConfigureGame.tsx`](diffhunk://#diff-049159a6686f8649cf4b310e2e5485eb7370f3cb430f7a116f566331ab49c27bL68-R68): Modified the `onChange` handler to parse the new value as a float before updating the `currentGameConfiguration` state.