### PR TITLE
Add end game confetti

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -25,6 +25,7 @@
     "next": "^15.1.2",
     "phaser": "^3.87.0",
     "react": "^19.0.0",
+    "react-confetti": "^6.2.2",
     "react-dom": "^19.0.0",
     "react-redux": "^9.2.0",
     "socket.io-client": "^4.8.1",

--- a/packages/games/package.json
+++ b/packages/games/package.json
@@ -14,6 +14,7 @@
     "motion": "^12.0.5",
     "phaser": "^3.87.0",
     "react": "^19.0.0",
+    "react-confetti": "^6.2.2",
     "react-dom": "^19.0.0",
     "uplot": "^1.6.31",
     "uuid": "^11.0.3"

--- a/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx
@@ -6,13 +6,17 @@ import { displayDollar } from "../utils/displayDollar";
 import styles from "./FinalScoreboard.module.scss";
 import { cycleTime } from "@resync-games/games-shared/theStockTimes/cycleTime";
 import { motion } from "motion/react";
+import Confetti from "react-confetti";
 
 export const FinalScoreboard = () => {
+  const currentGameState = useGameStateSelector(
+    (s) => s.gameStateSlice.gameInfo?.currentGameState
+  );
   const cycle = useGameStateSelector((s) => s.gameStateSlice.gameState?.cycle);
   const teams = useGameStateSelector(selectTotalTeamValue);
 
   // When the last day's articles come out, this should trigger
-  const isLastDay = (() => {
+  const isLastDayOfTrading = (() => {
     if (cycle === undefined) {
       return false;
     }
@@ -21,7 +25,9 @@ export const FinalScoreboard = () => {
     return day === cycle.endDay - 1;
   })();
 
-  if (isLastDay) {
+  const hasGameEnded = currentGameState === "finished";
+
+  if (isLastDayOfTrading) {
     return (
       <Flex direction="column" flex="1" gap="3" justify="center" px="5">
         <Flex
@@ -41,6 +47,9 @@ export const FinalScoreboard = () => {
       <Flex justify="center" mb="5">
         <Text size="9">Final scoreboard</Text>
       </Flex>
+      {hasGameEnded && (
+        <Confetti height={window.innerHeight} width={window.innerWidth} />
+      )}
       {teams.map((team, index) => (
         <motion.div
           animate={{ opacity: 1, y: 0 }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3252,6 +3252,7 @@ __metadata:
     motion: "npm:^12.0.5"
     phaser: "npm:^3.87.0"
     react: "npm:^19.0.0"
+    react-confetti: "npm:^6.2.2"
     react-dom: "npm:^19.0.0"
     ts-jest: "npm:^29.2.5"
     typescript: "npm:5.5.4"
@@ -3292,6 +3293,7 @@ __metadata:
     next: "npm:^15.1.2"
     phaser: "npm:^3.87.0"
     react: "npm:^19.0.0"
+    react-confetti: "npm:^6.2.2"
     react-dom: "npm:^19.0.0"
     react-redux: "npm:^9.2.0"
     sass: "npm:^1.83.0"
@@ -10367,6 +10369,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-confetti@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "react-confetti@npm:6.2.2"
+  dependencies:
+    tween-functions: "npm:^1.2.0"
+  peerDependencies:
+    react: ^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/c25250acc18a7e66a2a41aa429fee70a1e56346a73dced7aa64d8c8e87b96b478eb90933b530d1857832785eeb4a5978c5cb30080d187d32bbc68c3c0ef7f0a9
+  languageName: node
+  linkType: hard
+
 "react-dom@npm:^19.0.0":
   version: 19.0.0
   resolution: "react-dom@npm:19.0.0"
@@ -12133,6 +12146,13 @@ __metadata:
   bin:
     turbo: bin/turbo
   checksum: 10c0/9aab52fb868a2b6246f41fe2343dec56c70252a9cb7729a3ea183458cfa728c1445d1b98882dd43542f0ffd46524e8ba7776fe0925e31a86904b113222778fa5
+  languageName: node
+  linkType: hard
+
+"tween-functions@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tween-functions@npm:1.2.0"
+  checksum: 10c0/7e59295b8b0ee4132ed2fe335f56a9db5c87056dad6b6fd3011be72239fd20398003ddb4403bc98ad9f5c94468890830f64016edbbde35581faf95b32cda8305
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
On the final scoreboard, it displays confetti. How fun!

---

This pull request includes changes to integrate the `react-confetti` library into the `FinalScoreboard` component and update the `package.json` files accordingly. The most important changes include adding the `react-confetti` dependency and updating the logic in the `FinalScoreboard` component to display confetti when the game ends.

Dependency updates:

* [`packages/frontend/package.json`](diffhunk://#diff-8571ecd91584b00015b23695d3a6a164282636bb47bfbe46dca243bf9b4db773R28): Added `react-confetti` version `^6.2.2`.
* [`packages/games/package.json`](diffhunk://#diff-6f7eee10b1a6559860a8f817a108b303a175792491ccb370ccd04f7e0e93cf9bR17): Added `react-confetti` version `^6.2.2`.

Component updates:

* [`packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx`](diffhunk://#diff-f2bb0f2c95ad68730044318df7d89d24de7d461d429283dcafe0402341b62d9cR9-R19): Imported `Confetti` from `react-confetti`.
* [`packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx`](diffhunk://#diff-f2bb0f2c95ad68730044318df7d89d24de7d461d429283dcafe0402341b62d9cL24-R30): Added logic to use `currentGameState` and renamed `isLastDay` to `isLastDayOfTrading`.
* [`packages/games/src/frontend/theStockTimes/components/FinalScoreboard.tsx`](diffhunk://#diff-f2bb0f2c95ad68730044318df7d89d24de7d461d429283dcafe0402341b62d9cR50-R52): Displayed confetti when `hasGameEnded` is true.