### PR TITLE
Allow desktop to navigate to stock

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,4 @@
 cacheFolder: "./.yarn/cache"
+checksumBehavior: update
 enableGlobalCache: false
 nodeLinker: pnp

--- a/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
-import { useGameStateSelector } from "../store/theStockTimesRedux";
+import { ArrowLeftIcon, ArrowRightIcon } from "@radix-ui/react-icons";
 import { shuffle } from "lodash-es";
+import { motion } from "motion/react";
+import { useEffect, useMemo, useState } from "react";
 import { StockArticle } from "../../../backend/theStockTimes/theStockTimes";
 import { Button, Flex, Text } from "../../components";
-import styles from "./DayArticles.module.scss";
-import { ArrowLeftIcon, ArrowRightIcon } from "@radix-ui/react-icons";
 import { selectArticles } from "../store/selectors";
-import { motion } from "motion/react";
+import { useGameStateSelector } from "../store/theStockTimesRedux";
+import { ArticleText } from "./articles/ArticleText";
+import styles from "./DayArticles.module.scss";
 
 export const DayArticles = () => {
   const { articles, lastestAddedOn } = useGameStateSelector(selectArticles);
@@ -76,35 +77,39 @@ export const DayArticles = () => {
         </Flex>
       </Flex>
       <Flex direction="column" gap="2">
-        {viewingArticles.map((article) => (
-          <motion.div
-            animate={{ opacity: 1, x: 0 }}
-            initial={{ opacity: 0, x: -100 }}
-            key={article.title}
-          >
-            <Flex
-              className={styles.articlesContainer}
-              direction="column"
-              flex="1"
-              p="3"
+        {viewingArticles.map((article) => {
+          const title =
+            article.corruptedOn !== undefined ? "CORRUPTED" : article.title;
+          const description =
+            article.corruptedOn !== undefined
+              ? `[CORRUPTED] ${article.title}`
+              : article.description;
+          return (
+            <motion.div
+              animate={{ opacity: 1, x: 0 }}
+              initial={{ opacity: 0, x: -100 }}
+              key={article.title}
             >
-              <Flex justify="between">
-                <Text size="4" weight="bold">
-                  {article.corruptedOn !== undefined
-                    ? "CORRUPTED"
-                    : article.title}
-                </Text>
+              <Flex
+                className={styles.articlesContainer}
+                direction="column"
+                flex="1"
+                p="3"
+              >
+                <Flex justify="between">
+                  <Text size="4" weight="bold">
+                    <ArticleText text={title} />
+                  </Text>
+                </Flex>
+                <Flex>
+                  <Text color="gray">
+                    <ArticleText text={description} />
+                  </Text>
+                </Flex>
               </Flex>
-              <Flex>
-                <Text color="gray">
-                  {article.corruptedOn !== undefined
-                    ? `[CORRUPTED] ${article.title}`
-                    : article.description}
-                </Text>
-              </Flex>
-            </Flex>
-          </motion.div>
-        ))}
+            </motion.div>
+          );
+        })}
       </Flex>
     </Flex>
   );

--- a/packages/games/src/frontend/theStockTimes/components/articles/ArticleText.module.scss
+++ b/packages/games/src/frontend/theStockTimes/components/articles/ArticleText.module.scss
@@ -1,0 +1,5 @@
+@use "@/styles/variables.scss" as vars;
+
+.stock {
+    text-decoration: underline;
+}

--- a/packages/games/src/frontend/theStockTimes/components/articles/ArticleText.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/articles/ArticleText.tsx
@@ -1,0 +1,46 @@
+import clsx from "clsx";
+import { selectStocksAndSymbols } from "../../store/selectors";
+import {
+  updateTheStockTimesLocalState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "../../store/theStockTimesRedux";
+import styles from "./ArticleText.module.scss";
+import { Flex } from "../../../components";
+
+export const ArticleText = ({ text }: { text: string }) => {
+  const dispatch = useGameStateDispatch();
+  const stocksToSymbols = useGameStateSelector(selectStocksAndSymbols);
+
+  const setViewingStockSymbol = (stockSymbol: string) => () => {
+    dispatch(
+      updateTheStockTimesLocalState({ viewingStockSymbol: stockSymbol })
+    );
+  };
+
+  console.log(stocksToSymbols, "@@@");
+  const tokens = text.split(" ");
+
+  return (
+    <Flex gap="1" wrap="wrap">
+      {tokens.map((token, index) => {
+        const accordingSymbol = stocksToSymbols[token];
+        return (
+          <span
+            className={clsx({
+              [styles.stock ?? ""]: accordingSymbol !== undefined
+            })}
+            key={index}
+            onClick={
+              accordingSymbol
+                ? setViewingStockSymbol(accordingSymbol)
+                : undefined
+            }
+          >
+            {token}
+          </span>
+        );
+      })}
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/store/selectors.ts
+++ b/packages/games/src/frontend/theStockTimes/store/selectors.ts
@@ -144,6 +144,30 @@ export const selectArticles = createSelector(
   }
 );
 
+export const selectStocksAndSymbols = createSelector(
+  [(state: TheStockTimesReduxState) => state.gameStateSlice.gameState?.stocks],
+  (stocks) => {
+    if (stocks === undefined) {
+      return {};
+    }
+
+    const stocksToSymbols: { [stockSymbol: string]: string } =
+      Object.fromEntries(
+        Object.keys(stocks ?? {}).map((symbol) => [symbol, symbol])
+      );
+
+    for (const [symbol, stock] of Object.entries(stocks)) {
+      stocksToSymbols[stock.title] = symbol;
+
+      stock.title.split(" ").forEach((token) => {
+        stocksToSymbols[token] = symbol;
+      });
+    }
+
+    return stocksToSymbols;
+  }
+);
+
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 export const selectEndGameGraph = createSelector(


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and user interface of the `DayArticles` component in the `theStockTimes` game. The most important changes include the addition of new imports, the creation of a new `ArticleText` component, and the implementation of dynamic text rendering based on article data.

### Enhancements to the `DayArticles` component:

* [`packages/games/src/frontend/theStockTimes/components/DayArticles.tsx`](diffhunk://#diff-d86e52bb154f0c7ea2bc77d690a112db9d75005ba4c053b27c180a5b5c10934cL1-R10): Added new imports for `ArrowLeftIcon`, `ArrowRightIcon`, and `motion` to enhance the UI and animations. Reorganized existing imports for better readability.
* [`packages/games/src/frontend/theStockTimes/components/DayArticles.tsx`](diffhunk://#diff-d86e52bb154f0c7ea2bc77d690a112db9d75005ba4c053b27c180a5b5c10934cL79-R87): Implemented dynamic rendering of article titles and descriptions, including handling corrupted articles by displaying a "CORRUPTED" label. [[1]](diffhunk://#diff-d86e52bb154f0c7ea2bc77d690a112db9d75005ba4c053b27c180a5b5c10934cL79-R87) [[2]](diffhunk://#diff-d86e52bb154f0c7ea2bc77d690a112db9d75005ba4c053b27c180a5b5c10934cL93-R112)

### New `ArticleText` component:

* [`packages/games/src/frontend/theStockTimes/components/articles/ArticleText.tsx`](diffhunk://#diff-b4f8787094196c12b2340b82a19dccfcb25c4833937e200280f623afde0ef198R1-R46): Created a new `ArticleText` component to handle the display of article text, including clickable stock symbols that update the local state.
* [`packages/games/src/frontend/theStockTimes/components/articles/ArticleText.module.scss`](diffhunk://#diff-a6c30b7a710aaf1421eb68f39b993b110ebdae8321331bf218dc01e29d5973cdR1-R5): Added new styles for the `ArticleText` component, including an underline for stock symbols.

### Selector updates:

* [`packages/games/src/frontend/theStockTimes/store/selectors.ts`](diffhunk://#diff-dcc930a3e1cd3ef03fb28bf5ccf293724403a2338765212f13ca02e05dc6e3e0R147-R170): Added a new selector `selectStocksAndSymbols` to map stock titles and tokens to their corresponding symbols, facilitating the dynamic text rendering in the `ArticleText` component.

### Configuration update:

* [`.yarnrc.yml`](diffhunk://#diff-88fbe28c4102501b94961511a0d70ff895bf39970b4d3fc11917794a239117c5R2): Updated the Yarn configuration to include `checksumBehavior: update` for better dependency management.