### PR TITLE
Allow mobile games to navigate too

### DIFF
--- a/packages/games/src/frontend/theStockTimes/MobileGame.tsx
+++ b/packages/games/src/frontend/theStockTimes/MobileGame.tsx
@@ -7,19 +7,43 @@ import { PauseAndPlay } from "./components/cycle/PauseAndPlay";
 import { DayArticles } from "./components/DayArticles";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import styles from "./MobileGame.module.scss";
+import {
+  updateTheStockTimesLocalState,
+  useGameStateDispatch,
+  useGameStateSelector
+} from "./store/theStockTimesRedux";
 
 export const MobileGame = ({ gameState }: { gameState: TheStockTimesGame }) => {
+  const dispatch = useGameStateDispatch();
+
+  const viewingTab = useGameStateSelector(
+    (s) => s.localStateSlice.localState?.viewingTab
+  );
+
+  const handleTabChange = (tab: string) => () => {
+    dispatch(updateTheStockTimesLocalState({ viewingTab: tab }));
+  };
+
   return (
     <Flex className={styles.mainContainer} flex="1">
       <Flex align="center" className={styles.clock} flex="1" gap="2">
         <Clock cycle={gameState.cycle} size={60} />
         <PauseAndPlay />
       </Flex>
-      <Tabs.Root defaultValue="articles" style={{ width: "100%" }}>
+      <Tabs.Root style={{ width: "100%" }} value={viewingTab}>
         <Tabs.List>
-          <Tabs.Trigger value="portfolio">Portfolio</Tabs.Trigger>
-          <Tabs.Trigger value="articles">Articles</Tabs.Trigger>
-          <Tabs.Trigger value="stocks">Stocks</Tabs.Trigger>
+          <Tabs.Trigger
+            onClick={handleTabChange("portfolio")}
+            value="portfolio"
+          >
+            Portfolio
+          </Tabs.Trigger>
+          <Tabs.Trigger onClick={handleTabChange("articles")} value="articles">
+            Articles
+          </Tabs.Trigger>
+          <Tabs.Trigger onClick={handleTabChange("stocks")} value="stocks">
+            Stocks
+          </Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="portfolio">
           <motion.div

--- a/packages/games/src/frontend/theStockTimes/components/articles/ArticleText.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/articles/ArticleText.tsx
@@ -6,7 +6,6 @@ import {
   useGameStateSelector
 } from "../../store/theStockTimesRedux";
 import styles from "./ArticleText.module.scss";
-import { Flex } from "../../../components";
 
 export const ArticleText = ({ text }: { text: string }) => {
   const dispatch = useGameStateDispatch();
@@ -14,15 +13,17 @@ export const ArticleText = ({ text }: { text: string }) => {
 
   const setViewingStockSymbol = (stockSymbol: string) => () => {
     dispatch(
-      updateTheStockTimesLocalState({ viewingStockSymbol: stockSymbol })
+      updateTheStockTimesLocalState({
+        viewingStockSymbol: stockSymbol,
+        viewingTab: "stocks"
+      })
     );
   };
 
-  console.log(stocksToSymbols, "@@@");
-  const tokens = text.split(" ");
+  const tokens = text.split(/(?=\s|')/g);
 
   return (
-    <Flex gap="1" wrap="wrap">
+    <>
       {tokens.map((token, index) => {
         const accordingSymbol = stocksToSymbols[token];
         return (
@@ -41,6 +42,6 @@ export const ArticleText = ({ text }: { text: string }) => {
           </span>
         );
       })}
-    </Flex>
+    </>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/store/theStockTimesLocalState.ts
+++ b/packages/games/src/frontend/theStockTimes/store/theStockTimesLocalState.ts
@@ -1,7 +1,9 @@
 export interface TheStockTimesLocalState {
   viewingStockSymbol: string | undefined;
+  viewingTab: string;
 }
 
 export const INITIAL_THE_STOCK_TIMES_LOCAL_STATE: TheStockTimesLocalState = {
-  viewingStockSymbol: undefined
+  viewingStockSymbol: undefined,
+  viewingTab: "portfolio"
 };


### PR DESCRIPTION
This pull request includes changes to the `theStockTimes` game to improve state management and user experience by adding a new `viewingTab` state and updating related components accordingly. The most important changes include updating the local state, modifying tab handling in the `MobileGame` component, and adjusting the `ArticleText` component to set the viewing tab when a stock symbol is clicked.

State management improvements:

* [`packages/games/src/frontend/theStockTimes/store/theStockTimesLocalState.ts`](diffhunk://#diff-42c762afc75050d89109dd70736c9e4712077808835daa49434e3d74dc5d8547R3-R8): Added `viewingTab` to the `TheStockTimesLocalState` interface and initialized it to "portfolio".

Component updates:

* [`packages/games/src/frontend/theStockTimes/MobileGame.tsx`](diffhunk://#diff-883523ccf0cc074e90209385876023d5712a0b9a5347a7426f6718125aa85c34R10-R46): Added `useGameStateDispatch` and `useGameStateSelector` imports, and implemented state management for tab changes using `viewingTab` state.
* [`packages/games/src/frontend/theStockTimes/components/articles/ArticleText.tsx`](diffhunk://#diff-b4f8787094196c12b2340b82a19dccfcb25c4833937e200280f623afde0ef198L9-R26): Updated the `setViewingStockSymbol` function to also set the `viewingTab` to "stocks" and modified the token splitting logic for better text handling. [[1]](diffhunk://#diff-b4f8787094196c12b2340b82a19dccfcb25c4833937e200280f623afde0ef198L9-R26) [[2]](diffhunk://#diff-b4f8787094196c12b2340b82a19dccfcb25c4833937e200280f623afde0ef198L44-R45)