### PR TITLE
Make outside game components mobile friendly

### DIFF
--- a/packages/frontend/src/components/createGame/CreateGame.module.scss
+++ b/packages/frontend/src/components/createGame/CreateGame.module.scss
@@ -9,7 +9,6 @@
     border: 1px solid black;
     border-radius: 5px;
     padding: 20px;
-    width: 600px;
     height: fit-content;
     background: vars.$white;
 }

--- a/packages/frontend/src/components/createGame/CreateGame.tsx
+++ b/packages/frontend/src/components/createGame/CreateGame.tsx
@@ -50,7 +50,7 @@ export default function CreateGame() {
   };
 
   return (
-    <Flex className={styles.formBoxContainer} direction="column">
+    <Flex className={styles.formBoxContainer} direction="column" p="2">
       <Flex className={styles.formBox} direction="column" gap="3">
         <Text>Hi, {player.displayName}! Pick game to create</Text>
         <Flex direction="column" gap="2">

--- a/packages/frontend/src/components/inGame/GameLobby.module.scss
+++ b/packages/frontend/src/components/inGame/GameLobby.module.scss
@@ -1,22 +1,9 @@
 @use "@/styles/variables.scss" as vars;
 
-.configuration {
-    border-right: 1px solid vars.$black;
-    background: vars.$white;
-}
-
 .players {
     border-radius: 5px;
     background: vars.$white;
     border: 1px solid vars.$black;
     padding: 20px;
     min-width: 29vw;
-}
-
-.inviteLink {
-    cursor: pointer;
-
-    &:hover {
-        color: vars.$muted-font;
-    }
 }

--- a/packages/frontend/src/components/inGame/GameLobby.tsx
+++ b/packages/frontend/src/components/inGame/GameLobby.tsx
@@ -1,3 +1,4 @@
+import { DisplayPlayer } from "@/components/player/DisplayPlayer";
 import { Button } from "@/lib/radix/Button";
 import { Flex } from "@/lib/radix/Flex";
 import {
@@ -6,19 +7,15 @@ import {
 } from "@/lib/stableIdentifiers/teamIdentifier";
 import { useGameStateSelector } from "@/redux";
 import { ClientServiceCallers } from "@/services/serviceCallers";
-import { ClipboardCopyIcon, OpenInNewWindowIcon } from "@radix-ui/react-icons";
 import { Text } from "@radix-ui/themes";
 import { isServiceError } from "@resync-games/api";
-import copy from "copy-to-clipboard";
+import { motion } from "motion/react";
 import { useContext, useState } from "react";
 import { PlayerContext } from "../player/PlayerContext";
-import { ConfigureGame } from "./components/ConfigureGame";
 import { GoHome } from "./components/GoHome";
 import styles from "./GameLobby.module.scss";
 import { canStartGame } from "./utils/canStartGame";
-import { TutorialScreen } from "./components/TutorialScreen";
-import { motion } from "motion/react";
-import { DisplayPlayer } from "@/components/player/DisplayPlayer";
+import { GameConfigurationSideBar } from "./components/GameConfigurationSideBar";
 
 export const GameLobby = () => {
   const { gameInfo } = useGameStateSelector((s) => s.gameStateSlice);
@@ -78,52 +75,6 @@ export const GameLobby = () => {
     }
 
     console.error(response);
-  };
-
-  const renderRoomName = () => {
-    if (gameInfo === undefined) {
-      return;
-    }
-
-    const { gameName } = gameInfo;
-
-    const copyGameLink = () => copy(window.location.href);
-    const openGlobalScreen = () =>
-      window.open(`${window.location.href}/global`, "_blank");
-
-    return (
-      <Flex direction="column" gap="3">
-        <Flex align="center">
-          <Text size="8" weight="bold">
-            {gameName}
-          </Text>
-        </Flex>
-        <Flex
-          align="center"
-          className={styles.inviteLink}
-          gap="3"
-          onClick={copyGameLink}
-        >
-          <Text>Invite link</Text>
-          <ClipboardCopyIcon />
-        </Flex>
-        <Flex
-          align="center"
-          className={styles.inviteLink}
-          gap="3"
-          onClick={openGlobalScreen}
-        >
-          <Text
-            onClick={() =>
-              window.open(`${window.location.href}/global`, "_blank")
-            }
-          >
-            Global screen
-          </Text>
-          <OpenInNewWindowIcon />
-        </Flex>
-      </Flex>
-    );
   };
 
   const maybeRenderUndecided = () => {
@@ -221,22 +172,7 @@ export const GameLobby = () => {
       <Flex>
         <GoHome />
       </Flex>
-      <Flex
-        className={styles.configuration}
-        direction="column"
-        flex="1"
-        gap="5"
-        p="8"
-      >
-        {renderRoomName()}
-        <TutorialScreen key={gameInfo?.gameId + "tutorial"} />
-        <Flex direction="column" gap="4">
-          <Text color="gray" size="2">
-            Game configuration
-          </Text>
-          <ConfigureGame key={gameInfo?.gameId + "configure"} />
-        </Flex>
-      </Flex>
+      <GameConfigurationSideBar />
       <Flex direction="column" flex="4" gap="8" justify="center">
         {maybeRenderUndecided()}
         <Flex align="baseline" gap="3" justify="center">

--- a/packages/frontend/src/components/inGame/components/GameConfigurationSideBar.module.scss
+++ b/packages/frontend/src/components/inGame/components/GameConfigurationSideBar.module.scss
@@ -1,0 +1,27 @@
+@use "@/styles/variables.scss" as vars;
+
+.configuration {
+    border-right: 1px solid vars.$black;
+    background: vars.$white;
+    position: fixed;
+    left: 0;
+    top: 0;
+    bottom: 0;
+}
+
+.inviteLink {
+    cursor: pointer;
+
+    &:hover {
+        color: vars.$muted-font;
+    }
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(vars.$black, 0.25);
+}

--- a/packages/frontend/src/components/inGame/components/GameConfigurationSideBar.tsx
+++ b/packages/frontend/src/components/inGame/components/GameConfigurationSideBar.tsx
@@ -1,0 +1,118 @@
+import { useMediaQuery } from "@/lib/hooks/useMediaQuery";
+import { Flex } from "@/lib/radix";
+import { useGameStateSelector } from "@/redux";
+import { OpenInNewWindowIcon } from "@radix-ui/react-icons";
+import { Text } from "@radix-ui/themes";
+import copy from "copy-to-clipboard";
+import { ClipboardCopyIcon } from "@radix-ui/react-icons";
+import { motion } from "motion/react";
+import { useEffect, useState } from "react";
+import { ConfigureGame } from "./ConfigureGame";
+import styles from "./GameConfigurationSideBar.module.scss";
+import { TutorialScreen } from "./TutorialScreen";
+
+export const GameConfigurationSideBar = () => {
+  const { isMobile } = useMediaQuery();
+
+  const { gameInfo } = useGameStateSelector((s) => s.gameStateSlice);
+  const [isCollapsed, setIsCollapsed] = useState(isMobile);
+
+  useEffect(() => {
+    setIsCollapsed(isMobile);
+  }, [isMobile]);
+
+  const renderRoomName = () => {
+    if (gameInfo === undefined) {
+      return;
+    }
+
+    const { gameName } = gameInfo;
+
+    const copyGameLink = () => copy(window.location.href);
+    const openGlobalScreen = () =>
+      window.open(`${window.location.href}/global`, "_blank");
+
+    return (
+      <Flex direction="column" gap="3">
+        <Flex align="center">
+          <Text size="8" weight="bold">
+            {gameName}
+          </Text>
+        </Flex>
+        <Flex
+          align="center"
+          className={styles.inviteLink}
+          gap="3"
+          onClick={copyGameLink}
+        >
+          <Text>Invite link</Text>
+          <ClipboardCopyIcon />
+        </Flex>
+        <Flex
+          align="center"
+          className={styles.inviteLink}
+          gap="3"
+          onClick={openGlobalScreen}
+        >
+          <Text
+            onClick={() =>
+              window.open(`${window.location.href}/global`, "_blank")
+            }
+          >
+            Global screen
+          </Text>
+          <OpenInNewWindowIcon />
+        </Flex>
+      </Flex>
+    );
+  };
+
+  const maybeRenderContent = () => {
+    if (isCollapsed) {
+      return;
+    }
+
+    return (
+      <motion.div
+        animate={{ opacity: 1, x: 0 }}
+        initial={{ opacity: 0, x: -100 }}
+      >
+        <Flex direction="column" flex="1" gap="4" mt="7" p="3">
+          {renderRoomName()}
+          <TutorialScreen key={gameInfo?.gameId + "tutorial"} />
+          <Flex direction="column" gap="4">
+            <Text color="gray" size="2">
+              Game configuration
+            </Text>
+            <ConfigureGame key={gameInfo?.gameId + "configure"} />
+          </Flex>
+        </Flex>
+      </motion.div>
+    );
+  };
+
+  const maybeExpand = () => {
+    if (!isCollapsed || !isMobile) {
+      return;
+    }
+
+    setIsCollapsed(false);
+  };
+
+  return (
+    <>
+      {!isCollapsed && isMobile && (
+        <Flex className={styles.overlay} onClick={() => setIsCollapsed(true)} />
+      )}
+      <Flex
+        className={styles.configuration}
+        direction="column"
+        flex="1"
+        onClick={maybeExpand}
+        p="3"
+      >
+        {maybeRenderContent()}
+      </Flex>
+    </>
+  );
+};

--- a/packages/frontend/src/components/inGame/components/GoHome.module.scss
+++ b/packages/frontend/src/components/inGame/components/GoHome.module.scss
@@ -5,4 +5,5 @@
     top: 10px;
     left: 10px;
     background: vars.$white;
+    z-index: 1;
 }

--- a/packages/frontend/src/components/inGame/components/TutorialScreen.tsx
+++ b/packages/frontend/src/components/inGame/components/TutorialScreen.tsx
@@ -22,7 +22,7 @@ export const TutorialScreen = () => {
   const accordingGameName = GAME_REGISTRY[gameSlug]?.name;
 
   return (
-    <Flex direction="column" gap="4">
+    <Flex direction="column" gap="2">
       <Text color="gray" size="2">
         {accordingGameName} tutorial
       </Text>


### PR DESCRIPTION
This pull request includes several changes to the `GameLobby` component and its related styles and subcomponents, focusing on refactoring and improving the user interface by introducing a new `GameConfigurationSideBar` component.

Refactoring and UI improvements:

* [`packages/frontend/src/components/inGame/GameLobby.tsx`](diffhunk://#diff-31d84daddfc074dd51f09c47fc412788a35c34773eef9f075f3f47f0f352b12eL83-L128): Removed the inline configuration and invite link rendering logic, and replaced it with the new `GameConfigurationSideBar` component. [[1]](diffhunk://#diff-31d84daddfc074dd51f09c47fc412788a35c34773eef9f075f3f47f0f352b12eL83-L128) [[2]](diffhunk://#diff-31d84daddfc074dd51f09c47fc412788a35c34773eef9f075f3f47f0f352b12eL224-R175)
* [`packages/frontend/src/components/inGame/components/GameConfigurationSideBar.tsx`](diffhunk://#diff-99566b389ca91186c6d042c0ecb9d54afbebedce6916fd5c54c6119b51fbc4d1R1-R118): Added a new sidebar component to handle game configuration and invite link functionality, including responsive behavior for mobile devices.

Styling adjustments:

* [`packages/frontend/src/components/inGame/components/GameConfigurationSideBar.module.scss`](diffhunk://#diff-ce77deb9921ea19e2d48f9c32a356d4fef2e2ab9043177460978df4cceb0ceb6R1-R27): Added styles for the new sidebar component, including fixed positioning and hover effects.
* [`packages/frontend/src/components/inGame/GameLobby.module.scss`](diffhunk://#diff-8e64f00675b6086afd4f8d2a80738db186e12f84d6a2b83d247e551ef544bb66L3-L22): Removed the old configuration and invite link styles, as they are now handled by the new sidebar component.
* [`packages/frontend/src/components/inGame/components/GoHome.module.scss`](diffhunk://#diff-795ad4a1dcbd6c3ae6532aba09f8dc31b6356424fc8e936c17ae810ddfe9d0f0R8): Added a `z-index` to ensure the Go Home button is always visible.

Minor adjustments:

* [`packages/frontend/src/components/inGame/components/TutorialScreen.tsx`](diffhunk://#diff-9aae7586b4b9d9e22f7ab074fc27c3752b637f06ed8460cedd756f1b24e9fa77L25-R25): Adjusted the gap between elements in the tutorial screen for better spacing.
* [`packages/frontend/src/components/createGame/CreateGame.tsx`](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773L53-R53): Added padding to the main container for better spacing.