### PR TITLE
Switch deployment command

### DIFF
--- a/scripts/updateServer.sh
+++ b/scripts/updateServer.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yarn deploy;
+yarn deploy:restart;


### PR DESCRIPTION
This pull request includes a small but important change to the `scripts/updateServer.sh` file. The change modifies the deployment command to ensure the server restarts after deployment.

* [`scripts/updateServer.sh`](diffhunk://#diff-96a7ab9cb6961191ffae02b163272721287d6043a54998c24dab5bf88344b04eL3-R3): Changed the deployment command from `yarn deploy` to `yarn deploy:restart` to ensure the server restarts after deployment.