### PR TITLE
Remove articles and stock graphs from player

### DIFF
--- a/packages/games/src/frontend/theStockTimes/DesktopGame.tsx
+++ b/packages/games/src/frontend/theStockTimes/DesktopGame.tsx
@@ -1,12 +1,12 @@
-import { ScrollArea } from "@radix-ui/themes";
+import { TheStockTimesGame } from "../../backend/theStockTimes/theStockTimes";
 import { Flex } from "../components";
 import { AvailableStocks } from "./components/AvailableStocks";
 import { Clock } from "./components/cycle/Clock";
 import { PauseAndPlay } from "./components/cycle/PauseAndPlay";
-import { DayArticles } from "./components/DayArticles";
+import { FinalScoreboard } from "./components/FinalScoreboard";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import styles from "./DesktopGame.module.scss";
-import { TheStockTimesGame } from "../../backend/theStockTimes/theStockTimes";
+import { DisplayType } from "./utils/DisplayType";
 
 export const DesktopGame = ({
   gameState
@@ -14,28 +14,28 @@ export const DesktopGame = ({
   gameState: TheStockTimesGame;
 }) => {
   return (
-    <Flex className={styles.mainContainer} flex="1">
-      <Flex
-        align="center"
-        className={styles.clock}
-        direction="column"
-        flex="1"
-        gap="2"
-      >
-        <Clock cycle={gameState.cycle} />
-        <PauseAndPlay />
+    <DisplayType.Provider value={{ displayType: "desktop" }}>
+      <Flex className={styles.mainContainer} flex="1">
+        <Flex
+          align="center"
+          className={styles.clock}
+          direction="column"
+          flex="1"
+          gap="2"
+        >
+          <Clock cycle={gameState.cycle} />
+          <PauseAndPlay />
+        </Flex>
+        <Flex flex="1">
+          <PlayerPortfolio />
+        </Flex>
+        <Flex flex="1" ml="2">
+          <AvailableStocks />
+        </Flex>
+        <Flex flex="2" mr="5">
+          <FinalScoreboard />
+        </Flex>
       </Flex>
-      <Flex flex="1">
-        <PlayerPortfolio />
-      </Flex>
-      <Flex flex="1" ml="2">
-        <ScrollArea>
-          <DayArticles />
-        </ScrollArea>
-      </Flex>
-      <Flex flex="2" mr="5">
-        <AvailableStocks />
-      </Flex>
-    </Flex>
+    </DisplayType.Provider>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/MobileGame.tsx
+++ b/packages/games/src/frontend/theStockTimes/MobileGame.tsx
@@ -4,7 +4,7 @@ import { Flex, Tabs } from "../components";
 import { AvailableStocks } from "./components/AvailableStocks";
 import { Clock } from "./components/cycle/Clock";
 import { PauseAndPlay } from "./components/cycle/PauseAndPlay";
-import { DayArticles } from "./components/DayArticles";
+import { FinalScoreboard } from "./components/FinalScoreboard";
 import { PlayerPortfolio } from "./components/playerPortfolio/PlayerPortfolio";
 import styles from "./MobileGame.module.scss";
 import {
@@ -12,6 +12,7 @@ import {
   useStockTimesGameStateDispatch,
   useStockTimesSelector
 } from "./store/theStockTimesRedux";
+import { DisplayType } from "./utils/DisplayType";
 
 export const MobileGame = ({ gameState }: { gameState: TheStockTimesGame }) => {
   const dispatch = useStockTimesGameStateDispatch();
@@ -25,60 +26,65 @@ export const MobileGame = ({ gameState }: { gameState: TheStockTimesGame }) => {
   };
 
   return (
-    <Flex className={styles.mainContainer} flex="1">
-      <Flex align="center" className={styles.clock} flex="1" gap="2">
-        <Clock cycle={gameState.cycle} size={60} />
-        <PauseAndPlay />
+    <DisplayType.Provider value={{ displayType: "mobile" }}>
+      <Flex className={styles.mainContainer} flex="1">
+        <Flex align="center" className={styles.clock} flex="1" gap="2">
+          <Clock cycle={gameState.cycle} size={60} />
+          <PauseAndPlay />
+        </Flex>
+        <Tabs.Root style={{ width: "100%" }} value={viewingTab}>
+          <Tabs.List>
+            <Tabs.Trigger
+              onClick={handleTabChange("portfolio")}
+              value="portfolio"
+            >
+              Portfolio
+            </Tabs.Trigger>
+            <Tabs.Trigger onClick={handleTabChange("stocks")} value="stocks">
+              Stocks
+            </Tabs.Trigger>
+            <Tabs.Trigger
+              onClick={handleTabChange("scoreboard")}
+              value="scoreboard"
+            >
+              Scoreboard
+            </Tabs.Trigger>
+          </Tabs.List>
+          <Tabs.Content value="portfolio">
+            <motion.div
+              animate={{ opacity: 1, x: 0 }}
+              initial={{ opacity: 0, x: -100 }}
+              style={{ display: "flex", flex: "1" }}
+            >
+              <Flex flex="1" mt="2">
+                <PlayerPortfolio />
+              </Flex>
+            </motion.div>
+          </Tabs.Content>
+          <Tabs.Content style={{ height: "100%" }} value="stocks">
+            <motion.div
+              animate={{ opacity: 1, x: 0 }}
+              initial={{ opacity: 0, x: -100 }}
+              style={{ display: "flex", flex: "1", height: "100%" }}
+            >
+              <Flex flex="1" mt="2">
+                <AvailableStocks />
+              </Flex>
+            </motion.div>
+          </Tabs.Content>
+          <Tabs.Content value="scoreboard">
+            <motion.div
+              animate={{ opacity: 1, x: 0 }}
+              initial={{ opacity: 0, x: -100 }}
+              style={{ display: "flex", flex: "1" }}
+            >
+              <Flex flex="1" mt="2">
+                <FinalScoreboard />
+              </Flex>
+            </motion.div>
+          </Tabs.Content>
+        </Tabs.Root>
       </Flex>
-      <Tabs.Root style={{ width: "100%" }} value={viewingTab}>
-        <Tabs.List>
-          <Tabs.Trigger
-            onClick={handleTabChange("portfolio")}
-            value="portfolio"
-          >
-            Portfolio
-          </Tabs.Trigger>
-          <Tabs.Trigger onClick={handleTabChange("articles")} value="articles">
-            Articles
-          </Tabs.Trigger>
-          <Tabs.Trigger onClick={handleTabChange("stocks")} value="stocks">
-            Stocks
-          </Tabs.Trigger>
-        </Tabs.List>
-        <Tabs.Content value="portfolio">
-          <motion.div
-            animate={{ opacity: 1, x: 0 }}
-            initial={{ opacity: 0, x: -100 }}
-            style={{ display: "flex", flex: "1" }}
-          >
-            <Flex flex="1" mt="2">
-              <PlayerPortfolio />
-            </Flex>
-          </motion.div>
-        </Tabs.Content>
-        <Tabs.Content value="articles">
-          <motion.div
-            animate={{ opacity: 1, x: 0 }}
-            initial={{ opacity: 0, x: -100 }}
-            style={{ display: "flex", flex: "1" }}
-          >
-            <Flex flex="1" mt="2">
-              <DayArticles />
-            </Flex>
-          </motion.div>
-        </Tabs.Content>
-        <Tabs.Content style={{ height: "100%" }} value="stocks">
-          <motion.div
-            animate={{ opacity: 1, x: 0 }}
-            initial={{ opacity: 0, x: -100 }}
-            style={{ display: "flex", flex: "1", height: "100%" }}
-          >
-            <Flex flex="1" mt="2">
-              <AvailableStocks />
-            </Flex>
-          </motion.div>
-        </Tabs.Content>
-      </Tabs.Root>
-    </Flex>
+    </DisplayType.Provider>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
+++ b/packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx
@@ -3,6 +3,7 @@ import { Clock } from "./components/cycle/Clock";
 import { FinalScoreboard } from "./components/FinalScoreboard";
 import { EndGameGraph } from "./components/globalScreen/EndGameGraph";
 import { useStockTimesSelector } from "./store/theStockTimesRedux";
+import { DisplayType } from "./utils/DisplayType";
 
 export const StockTimesGlobalScreen = () => {
   const gameInfo = useStockTimesSelector((s) => s.gameStateSlice.gameInfo);
@@ -12,13 +13,13 @@ export const StockTimesGlobalScreen = () => {
     return;
   }
 
-  if (gameState.cycle.state === "paused") {
-    return (
-      <Flex align="center" flex="1" justify="center">
-        <Text color="gray">The game is paused</Text>
-      </Flex>
-    );
-  }
+  // if (gameState.cycle.state === "paused") {
+  //   return (
+  //     <Flex align="center" flex="1" justify="center">
+  //       <Text color="gray">The game is paused</Text>
+  //     </Flex>
+  //   );
+  // }
 
   if (gameInfo?.currentGameState === "waiting") {
     return (
@@ -37,13 +38,15 @@ export const StockTimesGlobalScreen = () => {
   }
 
   return (
-    <Flex flex="1" gap="2">
-      <Flex flex="1">
-        <FinalScoreboard />
+    <DisplayType.Provider value={{ displayType: "global-screen" }}>
+      <Flex flex="1" gap="2">
+        <Flex flex="1">
+          <FinalScoreboard />
+        </Flex>
+        <Flex flex="1">
+          <Clock cycle={gameState?.cycle} size={window.innerWidth / 2} />
+        </Flex>
       </Flex>
-      <Flex flex="1">
-        <Clock cycle={gameState?.cycle} size={window.innerWidth / 2} />
-      </Flex>
-    </Flex>
+    </DisplayType.Provider>
   );
 };

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx
@@ -1,9 +1,11 @@
+import { useContext } from "react";
 import { Flex } from "../../../components";
 import { useStockTimesSelector } from "../../store/theStockTimesRedux";
 import { PriceGraph } from "./PriceGraph";
 import { PurchaseStock } from "./PurchaseStock";
 import { StockDetails } from "./StockDetails";
 import { motion } from "motion/react";
+import { DisplayType } from "../../utils/DisplayType";
 
 export const SingleStock = ({
   viewingStockSymbol
@@ -15,9 +17,13 @@ export const SingleStock = ({
   );
   const thisStock = stocks?.[viewingStockSymbol];
 
+  const displayType = useContext(DisplayType);
+
   if (thisStock === undefined) {
     return;
   }
+
+  const isGlobalScreen = displayType.displayType === "global-screen";
 
   return (
     <motion.div
@@ -30,8 +36,12 @@ export const SingleStock = ({
           thisStock={thisStock}
           viewingStockSymbol={viewingStockSymbol}
         />
-        <PurchaseStock viewingStockSymbol={viewingStockSymbol} />
-        <PriceGraph viewingStockSymbol={viewingStockSymbol} />
+        {!isGlobalScreen && (
+          <PurchaseStock viewingStockSymbol={viewingStockSymbol} />
+        )}
+        {isGlobalScreen && (
+          <PriceGraph viewingStockSymbol={viewingStockSymbol} />
+        )}
       </Flex>
     </motion.div>
   );

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/StockDetails.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/StockDetails.tsx
@@ -6,6 +6,8 @@ import {
   useStockTimesGameStateDispatch
 } from "../../store/theStockTimesRedux";
 import styles from "./StockDetails.module.scss";
+import { DisplayType } from "../../utils/DisplayType";
+import { useContext } from "react";
 
 export const StockDetails = ({
   thisStock,
@@ -20,14 +22,19 @@ export const StockDetails = ({
     dispatch(updateTheStockTimesLocalState({ viewingStockSymbol: undefined }));
   };
 
+  const displayType = useContext(DisplayType);
+  const isGlobalScreen = displayType.displayType === "global-screen";
+
   return (
     <Flex className={styles.details} direction="column" p="3">
       <Flex align="center" gap="4">
-        <Flex>
-          <Button onClick={onGoBack} variant="outline">
-            <ArrowLeftIcon /> <Text>Back</Text>
-          </Button>
-        </Flex>
+        {!isGlobalScreen && (
+          <Flex>
+            <Button onClick={onGoBack} variant="outline">
+              <ArrowLeftIcon /> <Text>Back</Text>
+            </Button>
+          </Flex>
+        )}
         <Text size="4" weight="bold">
           {viewingStockSymbol} - {thisStock.title}
         </Text>

--- a/packages/games/src/frontend/theStockTimes/theStockTimesConfiguration.ts
+++ b/packages/games/src/frontend/theStockTimes/theStockTimesConfiguration.ts
@@ -4,18 +4,18 @@ import { MapGameConfiguration } from "../baseConfiguration";
 export const TheStockTimesConfiguration: MapGameConfiguration<TheStockTimesGameConfiguration> =
   {
     startingCash: {
-      default: 10_000,
+      default: 1_000,
       label: "Starting cash",
-      max: 100_000,
+      max: 50_000,
       min: 100,
       required: true,
       type: "number"
     },
     totalStocks: {
-      default: 8,
+      default: 4,
       label: "Total stocks",
-      max: 12,
-      min: 4,
+      max: 8,
+      min: 2,
       required: true,
       type: "number"
     }

--- a/packages/games/src/frontend/theStockTimes/utils/DisplayType.ts
+++ b/packages/games/src/frontend/theStockTimes/utils/DisplayType.ts
@@ -1,0 +1,9 @@
+import { createContext } from "react";
+
+export interface DisplayType {
+  displayType: "mobile" | "desktop" | "global-screen";
+}
+
+export const DisplayType = createContext<DisplayType>({
+  displayType: "global-screen"
+});


### PR DESCRIPTION
This pull request includes several changes to the `TheStockTimes` game to improve the user interface and functionality across different display types (mobile, desktop, and global screen). The most important changes include the addition of a `DisplayType` context, updates to various components to use this context, and modifications to the game configuration.

### Context and Component Updates:

* [`packages/games/src/frontend/theStockTimes/DesktopGame.tsx`](diffhunk://#diff-f0317d4111edb020938a57fc6c6a13fb7b2d556b01f1ae3fb9669a6db9f9c7feL1-R17): Added `DisplayType` context provider and replaced `DayArticles` component with `AvailableStocks` and `FinalScoreboard` components. [[1]](diffhunk://#diff-f0317d4111edb020938a57fc6c6a13fb7b2d556b01f1ae3fb9669a6db9f9c7feL1-R17) [[2]](diffhunk://#diff-f0317d4111edb020938a57fc6c6a13fb7b2d556b01f1ae3fb9669a6db9f9c7feL32-R39)
* [`packages/games/src/frontend/theStockTimes/MobileGame.tsx`](diffhunk://#diff-883523ccf0cc074e90209385876023d5712a0b9a5347a7426f6718125aa85c34L7-R15): Added `DisplayType` context provider, removed `DayArticles` component, and added `FinalScoreboard` component to the tabs. [[1]](diffhunk://#diff-883523ccf0cc074e90209385876023d5712a0b9a5347a7426f6718125aa85c34L7-R15) [[2]](diffhunk://#diff-883523ccf0cc074e90209385876023d5712a0b9a5347a7426f6718125aa85c34R29) [[3]](diffhunk://#diff-883523ccf0cc074e90209385876023d5712a0b9a5347a7426f6718125aa85c34L41-R51) [[4]](diffhunk://#diff-883523ccf0cc074e90209385876023d5712a0b9a5347a7426f6718125aa85c34L59-R88)
* [`packages/games/src/frontend/theStockTimes/StockTimesGlobalScreen.tsx`](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R6): Added `DisplayType` context provider and commented out code that handles the paused state of the game. [[1]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R6) [[2]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7L15-R22) [[3]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R41) [[4]](diffhunk://#diff-909c29e9267f08042e4e419e5b93fcbced8ad617635f60bbb72c5c528fe7c1f7R50)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/SingleStock.tsx`](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR1-R8): Used `DisplayType` context to conditionally render `PurchaseStock` and `PriceGraph` components based on the display type. [[1]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR1-R8) [[2]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR20-R27) [[3]](diffhunk://#diff-9618268be37ddcb68fdad0dccd49e5f65ab98061fb603c6430debcf0671111cfR39-R44)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/StockDetails.tsx`](diffhunk://#diff-e080df106b657ea9811b1f637b9e81d76fc7b94d4f2b86908151c63b314100c1R9-R10): Used `DisplayType` context to conditionally render the back button based on the display type. [[1]](diffhunk://#diff-e080df106b657ea9811b1f637b9e81d76fc7b94d4f2b86908151c63b314100c1R9-R10) [[2]](diffhunk://#diff-e080df106b657ea9811b1f637b9e81d76fc7b94d4f2b86908151c63b314100c1R25-R37)

### Game Configuration Updates:

* [`packages/games/src/frontend/theStockTimes/theStockTimesConfiguration.ts`](diffhunk://#diff-4c98e782ad836edee6ffb196ee3d2a53237c2e3f3bfc296cc38b0e609cfa8268L7-R18): Updated default values for `startingCash` and `totalStocks`, and adjusted their maximum values.

### New Context:

* [`packages/games/src/frontend/theStockTimes/utils/DisplayType.ts`](diffhunk://#diff-ce87abb2edceac40cb3faab072dbb69f1470f2763d3b1b045488644d1e2d9aeaR1-R9): Created a new `DisplayType` context to manage different display types (mobile, desktop, and global screen).