### PR TITLE
Add timer and other polish

### DIFF
--- a/packages/frontend/src/components/createGame/CreateGame.tsx
+++ b/packages/frontend/src/components/createGame/CreateGame.tsx
@@ -6,7 +6,7 @@ import { NavigationButton } from "@/lib/resync-components/NavigationButton";
 import { getFrontendGame } from "@/lib/utils/getFrontendGame";
 import { ClientServiceCallers } from "@/services/serviceCallers";
 import { ExitIcon } from "@radix-ui/react-icons";
-import { Button, Text } from "@radix-ui/themes";
+import { Button, ScrollArea, Text } from "@radix-ui/themes";
 import { isServiceError } from "@resync-games/api";
 import { useRouter } from "next/navigation";
 import { useContext, useState } from "react";
@@ -52,44 +52,49 @@ export default function CreateGame() {
   };
 
   return (
-    <Flex className={styles.formBoxContainer} direction="column" p="2">
-      <Flex className={styles.goHome}>
-        <NavigationButton href="/" variant="outline">
-          <ExitIcon />
-        </NavigationButton>
-      </Flex>
-      <Flex className={styles.formBox} direction="column" gap="3">
-        <Text>Hi, {player.displayName}! Pick game to create</Text>
-        <Flex direction="column" gap="2">
-          <Flex>
-            <Text color="gray" size="2">
-              Game type
-            </Text>
+    <ScrollArea>
+      <Flex className={styles.formBoxContainer} direction="column" p="2">
+        <Flex className={styles.goHome}>
+          <NavigationButton href="/" variant="outline">
+            <ExitIcon />
+          </NavigationButton>
+        </Flex>
+        <Flex className={styles.formBox} direction="column" gap="3">
+          <Text>Hi, {player.displayName}! Pick game to create</Text>
+          <Flex direction="column" gap="2">
+            <Flex>
+              <Text color="gray" size="2">
+                Game type
+              </Text>
+            </Flex>
+            <SelectGame
+              onSelectGame={onSelectGame}
+              selectedGame={selectedGame}
+            />
           </Flex>
-          <SelectGame onSelectGame={onSelectGame} selectedGame={selectedGame} />
-        </Flex>
-        <Flex direction="column" gap="2" my="2">
-          <Flex>
-            <Text color="gray" size="2">
-              Game name
-            </Text>
+          <Flex direction="column" gap="2" my="2">
+            <Flex>
+              <Text color="gray" size="2">
+                Game name
+              </Text>
+            </Flex>
+            <TextField
+              onChange={setGameName}
+              placeholder="Set the name of your game here..."
+              value={gameName}
+            />
           </Flex>
-          <TextField
-            onChange={setGameName}
-            placeholder="Set the name of your game here..."
-            value={gameName}
-          />
-        </Flex>
-        <Flex justify="end">
-          <Button
-            disabled={gameName === "" || selectedGame === undefined}
-            loading={isLoading}
-            onClick={onCreateGame}
-          >
-            Create game
-          </Button>
+          <Flex justify="end">
+            <Button
+              disabled={gameName === "" || selectedGame === undefined}
+              loading={isLoading}
+              onClick={onCreateGame}
+            >
+              Create game
+            </Button>
+          </Flex>
         </Flex>
       </Flex>
-    </Flex>
+    </ScrollArea>
   );
 }

--- a/packages/games/src/backend/theStockTimes/theStockTimes.ts
+++ b/packages/games/src/backend/theStockTimes/theStockTimes.ts
@@ -270,7 +270,7 @@ export class TheStockTimesServer
       gameState: {
         cycle: {
           dayTime: 60 * 1_000, // 60 seconds
-          endDay: 11000, // 10 full days = 13 minute game,
+          endDay: 11, // 10 full days = 13 minute game,
           lastUpdatedAt: new Date().toISOString(),
           nightTime: 20 * 1_000, // 20 seconds
           seedTime: 0,
@@ -376,7 +376,7 @@ export class TheStockTimesServer
 
     newGameState.cycle.startTime = new Date().toISOString();
 
-    const stockFocusCycleTime = game.gameConfiguration.stockCycleTime * 1_000;
+    const stockFocusCycleTime = game.gameConfiguration.stockCycleTime * 990;
     newGameState.stockInFocus.nextFocusIn = stockFocusCycleTime;
     newGameState.stockInFocus.stockOrder = Object.keys(newGameState.stocks);
 

--- a/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/DayArticles.tsx
@@ -41,13 +41,7 @@ export const DayArticles = () => {
   };
 
   return (
-    <Flex
-      className={styles.articlesContainer}
-      direction="column"
-      flex="1"
-      gap="3"
-      p="3"
-    >
+    <Flex className={styles.articlesContainer} direction="column" gap="3" p="3">
       {renderArticle()}
     </Flex>
   );

--- a/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx
@@ -11,6 +11,9 @@ export const PlayerStocks = () => {
   const stocks = useStockTimesSelector(
     (s) => s.gameStateSlice.gameState?.stocks
   );
+  const stockOrder = useStockTimesSelector(
+    (s) => s.gameStateSlice.gameState?.stockInFocus.stockOrder
+  );
 
   if (playerPortfolio === undefined) {
     return;
@@ -43,10 +46,14 @@ export const PlayerStocks = () => {
             (a, b) => new Date(a.date).valueOf() - new Date(b.date).valueOf()
           );
 
+        const stockIndex = (stockOrder ?? []).indexOf(symbol);
+
         return (
           <Flex direction="column" key={symbol}>
             <Flex align="center" className={styles.stockSymbol} gap="3">
-              <Text>{symbol}</Text>
+              <Text>
+                {symbol} ({stockIndex + 1} / {stockOrder?.length})
+              </Text>
               <Flex className={styles.divider} flex="1" />
               <Text color="green">{displayDollar(totalPrice)}</Text>
             </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/FocusedStock.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/FocusedStock.tsx
@@ -8,6 +8,7 @@ import { PriceGraph } from "./PriceGraph";
 import { PurchaseStock } from "./PurchaseStock";
 import { StockDetails } from "./StockDetails";
 import { selectFocusedStockData } from "../../store/selectors";
+import { FocusedStockTimer } from "./FocusedStockTimer";
 
 export const FocusedStock = () => {
   const stocks = useStockTimesSelector(selectFocusedStockData);
@@ -27,10 +28,9 @@ export const FocusedStock = () => {
       style={{ display: "flex", flex: "1" }}
     >
       <Flex direction="column" flex="1" gap="3" mx="4">
+        <FocusedStockTimer />
         <StockDetails thisStock={stock} viewingStockSymbol={symbol} />
-        <Flex>
-          <DayArticles />
-        </Flex>
+        {isGlobalScreen && <DayArticles />}
         {!isGlobalScreen && <PurchaseStock viewingStockSymbol={symbol} />}
         {isGlobalScreen && <PriceGraph stock={stock} />}
       </Flex>

--- a/packages/games/src/frontend/theStockTimes/components/singleStock/FocusedStockTimer.tsx
+++ b/packages/games/src/frontend/theStockTimes/components/singleStock/FocusedStockTimer.tsx
@@ -1,0 +1,17 @@
+import { Flex, Progress } from "../../../components";
+import { useFocusedStockTimer } from "../../hooks/focusedStockTimer";
+
+export const FocusedStockTimer = () => {
+  const { timeLeft } = useFocusedStockTimer();
+
+  const totalTimeLeft = 100 - timeLeft;
+
+  return (
+    <Flex>
+      <Progress
+        color={totalTimeLeft < 33 ? "red" : "blue"}
+        value={totalTimeLeft}
+      />
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/theStockTimes/hooks/focusedStockTimer.ts
+++ b/packages/games/src/frontend/theStockTimes/hooks/focusedStockTimer.ts
@@ -1,0 +1,38 @@
+import {
+  IsAvailable,
+  isAvailableAgainstClock
+} from "@resync-games/games-shared/theStockTimes/isAvailableAgainstClock";
+import { useEffect, useState } from "react";
+import { useStockTimesSelector } from "../store/theStockTimesRedux";
+
+export function useFocusedStockTimer(): IsAvailable {
+  const cycle = useStockTimesSelector((s) => s.gameStateSlice.gameState?.cycle);
+  const stockInFocus = useStockTimesSelector(
+    (s) => s.gameStateSlice.gameState?.stockInFocus
+  );
+
+  const [_, setCounter] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCounter((prev) => prev + 1);
+    }, 100);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (cycle === undefined || stockInFocus === undefined) {
+    return {
+      isAvailable: true,
+      timeLeft: 0
+    };
+  }
+
+  return isAvailableAgainstClock(
+    cycle,
+    stockInFocus.focusedAt,
+    stockInFocus.nextFocusIn
+  );
+}

--- a/packages/games/src/frontend/theStockTimes/utils/getRecentHistory.ts
+++ b/packages/games/src/frontend/theStockTimes/utils/getRecentHistory.ts
@@ -1,6 +1,6 @@
 import { StockPriceHistory } from "../../../backend/theStockTimes/theStockTimes";
 
-const RECENT_DATAPOINTS = 50;
+const RECENT_DATAPOINTS = 20;
 
 export function getRecentStockHistory(stockPriceHistory: StockPriceHistory[]) {
   const latestDataPoints = stockPriceHistory


### PR DESCRIPTION
This pull request includes several updates to the `CreateGame` component and the `TheStockTimes` game logic. The changes primarily focus on enhancing the UI and modifying game mechanics.

### UI Enhancements:

* [`packages/frontend/src/components/createGame/CreateGame.tsx`](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773L9-R9): Added `ScrollArea` for better scrolling support and improved code formatting for the `SelectGame` component. [[1]](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773L9-R9) [[2]](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773R55) [[3]](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773L69-R73) [[4]](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773R98)
* [`packages/games/src/frontend/theStockTimes/components/DayArticles.tsx`](diffhunk://#diff-d86e52bb154f0c7ea2bc77d690a112db9d75005ba4c053b27c180a5b5c10934cL44-R44): Simplified the `Flex` component's properties for better readability.
* [`packages/games/src/frontend/theStockTimes/components/playerPortfolio/PlayerStocks.tsx`](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeR14-R16): Added stock order display to the `PlayerStocks` component. [[1]](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeR14-R16) [[2]](diffhunk://#diff-e57ce122f4a88b30a2c26b820a4d3ad5bdd76e2ce070b5b1c3def25a50f0adbeR49-R56)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/FocusedStock.tsx`](diffhunk://#diff-d519ea01398bbf86dd9dd4bdac06d4d5a4596acbea58ccd288bec803b367b167R11): Introduced `FocusedStockTimer` to the `FocusedStock` component and conditionally rendered `DayArticles` and `PriceGraph` based on `isGlobalScreen`. [[1]](diffhunk://#diff-d519ea01398bbf86dd9dd4bdac06d4d5a4596acbea58ccd288bec803b367b167R11) [[2]](diffhunk://#diff-d519ea01398bbf86dd9dd4bdac06d4d5a4596acbea58ccd288bec803b367b167R31-R33)
* [`packages/games/src/frontend/theStockTimes/components/singleStock/FocusedStockTimer.tsx`](diffhunk://#diff-e8a890fb2ee68cd34d2026e82ada5d6ab2c500f39c3f170e250a3257f1be4e6aR1-R17): Added a new `FocusedStockTimer` component to display a progress bar for the stock focus timer.

### Game Mechanics Updates:

* [`packages/games/src/backend/theStockTimes/theStockTimes.ts`](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L273-R273): Corrected `endDay` value and adjusted `stockCycleTime` to improve game timing accuracy. [[1]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L273-R273) [[2]](diffhunk://#diff-2f6bd34f8ae785d7c74780b888f6198dc93d7799f51f5aa8699d8b33a9ff1e01L379-R379)
* [`packages/games/src/frontend/theStockTimes/hooks/focusedStockTimer.ts`](diffhunk://#diff-fc7f1f1779908f1243c66829aaa3df45ae6dea7995b934f6066e27d9bb259292R1-R38): Created a custom hook `useFocusedStockTimer` to manage the stock focus timer logic.
* [`packages/games/src/frontend/theStockTimes/utils/getRecentHistory.ts`](diffhunk://#diff-17be8deb8f2ba9e50261a0d17742f0202c043e3f92d6c83fff49c7bfecc30a67L3-R3): Reduced the number of recent data points from 50 to 20 for stock price history.