### PR TITLE
Add a bunch of dares for something unrelated

### DIFF
--- a/packages/backend/src/assets/dares.json
+++ b/packages/backend/src/assets/dares.json
@@ -1,0 +1,204 @@
+[{
+    "dareText":
+      "_C_ needs to make some toast, except _B_ is the toaster and _A_ is the bread.",
+    "totalPlayers": 3
+  },
+  {
+    "dareText": "_A_ needs to text their mom 'Happy Birthday!'",
+    "totalPlayers": 1
+  },
+  {
+    "dareText":
+      "_B_ is the runway model and _A_ is the announcer. Put on a fashion show.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ needs to break dance to a song chosen by _B_.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ need to put on a shadow puppet performance.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ needs to wash their face...with beer.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_B_ is the chef, and _A_ is the bacon. Make it sizzle!",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ gives us their best spongebob squarepants impression.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ is the bull and _B_ is the matador. Bullfight!",
+    "totalPlayers": 2
+  },
+  {
+    "dareText":
+      "_B_ takes a funny photo of _A_ and _C_ sends the photo to their dad.",
+    "totalPlayers": 3
+  },
+  {
+    "dareText": "_A_ must act like a robot whose battery is slowly dying.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ and _B_ must perform a dramatic soap opera scene about a stolen sandwich.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ narrates everything _B_ does for the next 1 minute in a nature documentary voice. _B_ pretends to be a peacock during mating season.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ must draw a self-portrait using only their non-dominant hand.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ has to surf on _B_ and do their best impression of Luke wiping out.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ has to sing the chorus of a popular song as if they’re underwater.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_B_ and _C_ form a throne for _A_ to sit on. _A_ must hold court asking the citizens (the rest of the group) for their grievances against the birthday boy.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ gives a 30-second TED Talk about why socks are better than shoes.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ and _B_ act out a scene where _B_ is a dog and _A_ is its owner. _A_ forgot poop bags.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ is the momma bird trying to feed _B_ the baby bird. _B_ does not want to eat.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ must keep a straight face while _B_ does their best pterodactyl impression.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ perform a duet, using only the birthday boy's body for music.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ must do their best impression of the birthday boy talking to himself.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ has to balance a spoon on their nose and pretends to be a scratch post...while _B_ pretends to be a cat.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ must crawl around like a crab and convince the birthday boy to take his shirt off.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ is _B_'s therapist, convincing them they're using too much toothpaste.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ must pretend the floor is lava for 30 seconds. _B_ is the lava monster.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ create a secret handshake. They must teach everyone without the birthday boy finding out.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ has to put on a puppet show using the birthday boy as their only prop.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ must compliment the birthday boy using only surfing metaphors.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_, _B_, and _C_ play duck duck goose around the birthday boy.",
+    "totalPlayers": 3
+  },
+  {
+    "dareText": "_A_ sits in the middle of the circle and makes platypus sounds until the next round.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ is the birthday boy's angel, _B_ is the birthday boy's devil. They have an argument about the birthday boy using a butt plug.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ are podcast hosts. They bring on their celebrity guest, the birthday boy.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_B_ must steal something from the birthday boy. _A_ must solve the mystery of what was stolen.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ has to recite the alphabet backwards while hopping on one foot. _B_ does their best to distract _A_.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ are on a cooking show. They're making shithole...pie? They have to tell us what region of the world it's from and how to make it.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ has to make a hat out of nearby objects and wear it for the next round.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_A_ is a sleep-deprived scientist and _B_ is their experimental talking plant. _C_ is the journalist interviewing them.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ must reenact a dramatic scene from a telenovela about a missing sock. _C_ is the sock.",
+    "totalPlayers": 3
+  },
+  {
+    "dareText": "_A_ gives a weather forecast of the birthday boy's emotional state.",
+    "totalPlayers": 1
+  },
+  {
+    "dareText": "_B_ must convince _A_ that their body is being replaced by spaghetti. _A_ reacts accordingly.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ come up with instructions on how to drink. The birthday boy must follow their instructions to drink.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ must act out a cooking competition where the main ingredient is the birthday boy. _C_ is the judge.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ are racist wizards who were caught casting not approved spells. They are currently in an HR meeting with _C_.",
+    "totalPlayers": 3
+  },
+  {
+    "dareText": "_A_ must make an infomercial selling the birthday boy as a product. _B_ is the skeptical customer.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ are royal horses. Have the birthday boy ride in to attend the ball in style.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ are fortune tellers giving the birthday boy a dramatic reading of his palms.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ and _B_ must act like a medieval bard singing the tale of the birthday boy's greatest achievement.",
+    "totalPlayers": 2
+  },
+  {
+    "dareText": "_A_ is a game show host. _B_ and _C_ are the contestant answering trivia questions about the birthday boy's life. The answers must be made up.",
+    "totalPlayers": 3
+  }
+]

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -20,9 +20,9 @@
     "esModuleInterop": true,
     "paths": {
       "@/*": ["./src/*"],
-      "@resync-games/api": ["../api/index.ts"],
-      "@resync-games/games": ["../games/src/backend/index.ts"],
-      "@resync-games/games-shared": ["../games/src/shared/index.ts"],
+      "@resync-games/api": ["../api"],
+      "@resync-games/games": ["../games/src/backend"],
+      "@resync-games/games-shared": ["../games/src/shared"],
     },
   },
   "include": ["**/*.ts", "../api/**/*.ts", "../games/src/backend/**/*.ts", "../games/src/shared/**/*.ts"],

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -29,9 +29,9 @@
     "paths": {
       "@/*": ["./src/*"],
       "@resync-games/frontend/*": ["./src/*"],
-      "@resync-games/api": ["../api/index.ts"],
-      "@resync-games/games": ["../games/src/frontend/index.ts"],
-      "@resync-games/games-shared": ["../games/src/shared/index.ts"]
+      "@resync-games/api": ["../api"],
+      "@resync-games/games": ["../games/src/frontend"],
+      "@resync-games/games-shared": ["../games/src/shared"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "../api/**/*.ts", "../games/src/frontend/**/*.tsx", "../games/src/shared/**/*.ts", ".next/types/**/*.ts"],


### PR DESCRIPTION
Was creating dares for something else, seemed fun to track here. Maybe we can use this for something else in the future?

---

This pull request introduces a new set of dares for a game and updates the TypeScript configuration files to simplify module path mappings. Below is a summary of the key changes:

### New Features
* Added a comprehensive list of 50 creative and humorous dares to the `dares.json` file, designed for various player counts and scenarios. These dares enhance game content and provide diverse challenges for players.

### Configuration Updates
* Updated `tsconfig.json` in `packages/backend` to simplify path mappings for `@resync-games/api`, `@resync-games/games`, and `@resync-games/games-shared` by removing explicit `index.ts` references.
* Updated `tsconfig.json` in `packages/frontend` with similar path mapping simplifications, ensuring consistency across the project.