### PR TITLE
Add active word and someone got it!

### DIFF
--- a/packages/frontend/src/app/blog/engineering/monorepo-culture/page.tsx
+++ b/packages/frontend/src/app/blog/engineering/monorepo-culture/page.tsx
@@ -43,8 +43,8 @@ export default function MonorepoCulture() {
         </ul>
       </PlainBlogText>
       <BlogText>
-        So much incredible good happens when those two things are true. And for
-        me, it's all about that feeling of being together, which I've always
+        So much incredible good happens when those three things are true. And
+        for me, it's all about that feeling of being together, which I've always
         felt on high-functioning teams. That feeling that our team is working
         together toward the same shared goals.
       </BlogText>

--- a/packages/frontend/src/components/joinGame/JoinGame.tsx
+++ b/packages/frontend/src/components/joinGame/JoinGame.tsx
@@ -34,7 +34,7 @@ export function JoinGame() {
     <Flex direction="column">
       <Flex gap="2">
         <TextField
-          maxLength={5}
+          maxLength={6}
           onChange={setInviteCode}
           placeholder="Invite code..."
           size="3"

--- a/packages/games/src/backend/fishbowl/fishbowl.ts
+++ b/packages/games/src/backend/fishbowl/fishbowl.ts
@@ -141,6 +141,10 @@ export interface FishbowlGame extends WithTimestamp {
    */
   gameWords: FishbowlWord[];
   /**
+   * The rounds that have been played in the game, just for historical reference.
+   */
+  pastRounds: FishbowlRound[];
+  /**
    * All the guesses that have been made by all players in the game.
    */
   playerGuesses: FishbowlAllPlayerGuesses;
@@ -186,6 +190,7 @@ export class FishbowlServer
       gameState: {
         gameWords: [],
         lastUpdatedAt: new Date().toISOString(),
+        pastRounds: [],
         playerGuesses: {},
         playerWordContributions: {},
         round: undefined,

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
@@ -3,6 +3,8 @@ import { useFishbowlSelector } from "../../store/fishbowlRedux";
 import { selectActiveRound } from "../../store/selectors";
 import { FishbowlTimer } from "../timer/FishbowlTimer";
 import { TimerControl } from "./TimerControl";
+import { ActiveWord } from "./ActiveWord";
+import { SomeoneGotIt } from "./SomeoneGotIt";
 
 export const ActivePlayer = () => {
   const timer = useFishbowlSelector(
@@ -14,10 +16,27 @@ export const ActivePlayer = () => {
     return;
   }
 
+  if (timer.state !== "running") {
+    return (
+      <Flex align="center" flex="1" gap="2" justify="center">
+        <FishbowlTimer timer={timer} />
+        <TimerControl />
+      </Flex>
+    );
+  }
+
   return (
-    <Flex align="center" flex="1" gap="2" justify="center">
-      <FishbowlTimer timer={timer} />
-      <TimerControl />
+    <Flex align="center" direction="column" flex="1" gap="4" justify="center">
+      <Flex direction="column" gap="4">
+        <Flex align="center" gap="2">
+          <ActiveWord />
+          <FishbowlTimer timer={timer} />
+        </Flex>
+        <Flex align="center" gap="2">
+          <SomeoneGotIt />
+          <TimerControl />
+        </Flex>
+      </Flex>
     </Flex>
   );
 };

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/ActiveWord.module.scss
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/ActiveWord.module.scss
@@ -1,0 +1,8 @@
+@use "@/styles/variables.scss" as vars;
+
+.wordContainer {
+    background: vars.$white;
+    border-radius: 5px;
+    border: 1px solid vars.$black;
+    user-select: none;
+}

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/ActiveWord.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/ActiveWord.tsx
@@ -1,0 +1,44 @@
+import { DisplayText, Flex } from "@/lib/radix";
+import { useFishbowlSelector } from "../../store/fishbowlRedux";
+import styles from "./ActiveWord.module.scss";
+import { useState } from "react";
+import { Eye, EyeClosed } from "lucide-react";
+
+export const ActiveWord = () => {
+  const [viewingWord, setViewingWord] = useState(false);
+  const activeWord = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round?.currentActiveWord
+  );
+
+  if (activeWord === undefined) {
+    return;
+  }
+
+  const onViewWord = () => setViewingWord(true);
+  const onHideWord = () => setViewingWord(false);
+
+  return (
+    <Flex
+      align="center"
+      className={styles.wordContainer}
+      flex="1"
+      justify="center"
+      onMouseDown={onViewWord}
+      onMouseUp={onHideWord}
+      onTouchEnd={onHideWord}
+      onTouchStart={onViewWord}
+      p="4"
+    >
+      <Flex align="center" gap="2">
+        {viewingWord ? <Eye size={20} /> : <EyeClosed size={20} />}
+        <DisplayText
+          size="9"
+          style={{ opacity: viewingWord ? 1 : 0.05 }}
+          weight="bold"
+        >
+          {activeWord.word}
+        </DisplayText>
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/lib/radix";
+import {
+  updateFishbowlGameState,
+  useFishbowlDispatch,
+  useFishbowlSelector
+} from "../../store/fishbowlRedux";
+import { selectActiveRound, selectFishbowlPlayer } from "../../store/selectors";
+import { FishbowlRound } from "../../../../backend";
+import { cloneDeep, isEqual, sample } from "lodash-es";
+
+export const SomeoneGotIt = () => {
+  const dispatch = useFishbowlDispatch();
+
+  const activePlayer = useFishbowlSelector(selectFishbowlPlayer);
+  const activeRound = useFishbowlSelector(selectActiveRound);
+  if (activePlayer === undefined || activeRound === undefined) {
+    return;
+  }
+
+  const onAdvanceWord = () => {
+    const updatedRound: FishbowlRound = cloneDeep(activeRound);
+    updatedRound.lastUpdatedAt = new Date().toISOString();
+
+    updatedRound.correctGuesses.push({
+      ...activeRound.currentActiveWord,
+      currentActivePlayer: activeRound.currentActivePlayer.player,
+      guess: activeRound.currentActiveWord.word,
+      guessingPlayer: activePlayer,
+      roundNumber: activeRound.roundNumber,
+      timestamp: new Date().toISOString()
+    });
+
+    const newWord = sample(updatedRound.remainingWords);
+    if (newWord === undefined) {
+      // Round has ended! Need to start a new round.
+      updatedRound.remainingWords = [];
+      return;
+    }
+
+    updatedRound.currentActiveWord = newWord;
+    const newWordIndex = updatedRound.remainingWords.findIndex((word) =>
+      isEqual(word, newWord)
+    );
+    updatedRound.remainingWords.splice(newWordIndex, 1);
+
+    dispatch(
+      updateFishbowlGameState(
+        {
+          round: updatedRound
+        },
+        activePlayer
+      )
+    );
+  };
+
+  return <Button onClick={onAdvanceWord}>Someone got it!</Button>;
+};

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/TimerControl.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/TimerControl.tsx
@@ -74,16 +74,20 @@ export const TimerControl = () => {
     );
   };
 
+  const playText = timer.seedTime !== 0 ? "Resume" : "Start";
+
   return (
     <Flex>
       <Button
         onClick={timer.state === "running" ? onPause : onStart}
-        variant="outline"
+        variant={timer.state === "running" ? "outline" : "solid"}
       >
         {timer.state === "running" ? (
           <PauseIcon size={16} />
         ) : (
-          <PlayIcon size={16} />
+          <>
+            {playText} <PlayIcon size={16} />
+          </>
         )}
       </Button>
     </Flex>

--- a/packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.module.scss
+++ b/packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.module.scss
@@ -1,9 +1,16 @@
 @use "@/styles/variables.scss" as vars;
 
-.baseClock {
-    fill: vars.$yellow;
+.clock {
     stroke: vars.$black;
     stroke-width: 1;
+}
+
+.greenTime {
+    fill: vars.$green;
+}
+
+.lowTime {
+    fill: vars.$red;
 }
 
 .pointer {

--- a/packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.tsx
@@ -33,15 +33,9 @@ export const FishbowlTimer = ({
   const { timeFraction } = useTimer(timer);
   const finalSize = size ?? DEFAULT_SIZE;
 
-  if (timer?.state === "stopped") {
-    return <Flex>Stopped</Flex>;
+  if (timer?.state === "stopped" || timer?.state === "paused") {
+    return;
   }
-
-  if (timer?.state === "paused") {
-    return <Flex>Paused</Flex>;
-  }
-
-  console.log({ timeFraction });
 
   return (
     <>
@@ -49,7 +43,10 @@ export const FishbowlTimer = ({
       <Flex align="center" gap="1">
         <svg height={finalSize} width={finalSize}>
           <circle
-            className={styles.baseClock}
+            className={clsx(styles.clock, {
+              [styles.greenTime ?? ""]: timeFraction <= 0.8,
+              [styles.lowTime ?? ""]: timeFraction > 0.8
+            })}
             cx={centerX(finalSize)}
             cy={centerY(finalSize)}
             r={radius(finalSize)}
@@ -58,6 +55,11 @@ export const FishbowlTimer = ({
             className={styles.pointer}
             d={calculateClockPointer(timeFraction, finalSize)}
             strokeWidth={finalSize / 20}
+          />
+          <path
+            className={styles.pointer}
+            d={calculateClockPointer(0, finalSize)}
+            strokeWidth={finalSize / 15}
           />
           <circle
             cx={centerX(finalSize)}


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across the codebase, primarily focusing on improving the Fishbowl game functionality, user interface, and styling. Key changes include the addition of new features to the active player view, updates to timer behavior and visuals, and the introduction of new game state properties.

### Fishbowl Game Enhancements:
* Added `pastRounds` property to the `FishbowlGame` interface to track historical game rounds and initialized it in the `FishbowlServer` class. [[1]](diffhunk://#diff-62a5e588fb461601e0f396ff183c9da94013e364673b703468396e250ea3535eR143-R146) [[2]](diffhunk://#diff-62a5e588fb461601e0f396ff183c9da94013e364673b703468396e250ea3535eR193)
* Introduced the `ActiveWord` and `SomeoneGotIt` components to enhance the active player view, allowing players to interact with the current word and mark it as guessed. [[1]](diffhunk://#diff-491c34f4e8e502f1bedba080c0ec6f5e0f1ed69df1b12d7f83cc6d7308686688R6-R7) [[2]](diffhunk://#diff-491c34f4e8e502f1bedba080c0ec6f5e0f1ed69df1b12d7f83cc6d7308686688R19-R41) [[3]](diffhunk://#diff-99b321f13876c02c1da5e1547d756be72e299bbd87b73a03034b48a16527eef3R1-R44) [[4]](diffhunk://#diff-39b540bd4e59e539fe9c11de1d23d28ecfacd97683d6580b276ef79c1b5baba6R1-R57)

### Timer Improvements:
* Updated `FishbowlTimer` to visually differentiate between time states (normal, low, and critical) using new styles and added a pointer to indicate the start of the timer. [[1]](diffhunk://#diff-8ce01495c7a83817c758b57e6ecc89bfc1471e25b78b43a6939bb32eafdc638dL3-R15) [[2]](diffhunk://#diff-69da7a872022d0020c9600c3da4c8be48ddef6e5072ac219cebf4748033cf121L36-R49) [[3]](diffhunk://#diff-69da7a872022d0020c9600c3da4c8be48ddef6e5072ac219cebf4748033cf121R59-R63)
* Adjusted `TimerControl` to display more intuitive button text ("Start" or "Resume") and use a solid variant for the play button when the timer is not running.

### UI and Styling Updates:
* Added a new `ActiveWord.module.scss` file to style the `ActiveWord` component, including a container with a white background and black border.
* Updated the `maxLength` of the invite code input field in the `JoinGame` component from 5 to 6 to accommodate longer codes.

### Blog Text Fix:
* Corrected a minor textual error in the "Monorepo Culture" blog post, changing "two things" to "three things" to align with the context.