### PR TITLE
Add switching player to global screen

### DIFF
--- a/packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx
+++ b/packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx
@@ -15,5 +15,9 @@ export const DisplayFishbowl = () => {
     return <ActivePlayer />;
   }
 
-  return <Flex>Guessing</Flex>;
+  return (
+    <Flex align="center" flex="1" justify="center">
+      Guessing
+    </Flex>
+  );
 };

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
@@ -19,7 +19,6 @@ export const ActivePlayer = () => {
   if (timer.state !== "running") {
     return (
       <Flex align="center" flex="1" gap="2" justify="center">
-        <FishbowlTimer timer={timer} />
         <TimerControl />
       </Flex>
     );

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/TimerControl.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/TimerControl.tsx
@@ -74,7 +74,7 @@ export const TimerControl = () => {
     );
   };
 
-  const playText = timer.seedTime !== 0 ? "Resume" : "Start";
+  const playText = timer.seedTime !== 0 ? "Resume" : "Start your turn";
 
   return (
     <Flex>

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
@@ -1,10 +1,13 @@
+import { PlayerIcon } from "@/components/player/PlayerIcon";
 import { DisplayText, Flex } from "@/lib/radix";
 import { useFishbowlSelector } from "../../store/fishbowlRedux";
 import { FishbowlTimer } from "../timer/FishbowlTimer";
-import { PlayerIcon } from "@/components/player/PlayerIcon";
 import styles from "./RoundInProgress.module.scss";
+import { useAdvancePlayer } from "./hooks/useAdvancePlayer";
 
 export const RoundInProgress = () => {
+  useAdvancePlayer();
+
   const activeRound = useFishbowlSelector(
     (s) => s.gameStateSlice.gameState?.round
   );

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/StartGame.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/StartGame.tsx
@@ -41,6 +41,7 @@ export const StartGame = () => {
       (p) => p.playerId === gameState.turnOrder[0]
     );
     if (activePlayer === undefined) {
+      // Something went wrong here, we should error out
       return;
     }
 

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/hooks/useAdvancePlayer.ts
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/hooks/useAdvancePlayer.ts
@@ -1,0 +1,102 @@
+import { useEffect } from "react";
+import { useTimer } from "../../../hooks/useTimer";
+import {
+  updateFishbowlGameState,
+  useFishbowlDispatch,
+  useFishbowlSelector
+} from "../../../store/fishbowlRedux";
+import {
+  FishbowlActivePlayer,
+  FishbowlActiveTracker,
+  FishbowlGameConfiguration,
+  FishbowlRound
+} from "../../../../../backend";
+import { cloneDeep } from "lodash-es";
+import { PlayerId } from "../../../../../../imports/api";
+
+export function useAdvancePlayer() {
+  const dispatch = useFishbowlDispatch();
+
+  const activeRound = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round
+  );
+  const turnOrder = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.turnOrder
+  );
+  const allPlayers = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameInfo?.players
+  );
+  const gameConfiguration = useFishbowlSelector(
+    (s) =>
+      s.gameStateSlice.gameInfo?.gameConfiguration as
+        | FishbowlGameConfiguration
+        | undefined
+  );
+
+  const timer = useTimer(activeRound?.currentActivePlayer.timer);
+
+  const advanceToNextPlayer = () => {
+    if (
+      activeRound === undefined ||
+      turnOrder === undefined ||
+      allPlayers === undefined ||
+      gameConfiguration === undefined
+    ) {
+      return;
+    }
+
+    const newFishbowlRound: FishbowlRound = cloneDeep(activeRound);
+    newFishbowlRound.lastUpdatedAt = new Date().toISOString();
+
+    const currentPlayerIndex = turnOrder.findIndex(
+      (order) => order === activeRound.currentActivePlayer.player.playerId
+    );
+    const nextPlayerIndex = (currentPlayerIndex + 1) % turnOrder.length;
+    const nextPlayer = allPlayers.find(
+      (player) => player.playerId === turnOrder[nextPlayerIndex]
+    );
+    if (nextPlayer === undefined) {
+      // Something went wrong here, we should error out
+      return;
+    }
+
+    const fishbowlActiveTracker: FishbowlActiveTracker = {
+      countdownTimer: (gameConfiguration.timePerPlayer[1] ?? 0) * 1000,
+      lastUpdatedAt: new Date().toISOString(),
+      seedTime: 0,
+      startTime: 0,
+      state: "paused"
+    };
+
+    const nextActivePlayer: FishbowlActivePlayer = {
+      lastUpdatedAt: new Date().toISOString(),
+      player: nextPlayer,
+      timer: fishbowlActiveTracker
+    };
+    newFishbowlRound.currentActivePlayer = nextActivePlayer;
+
+    dispatch(
+      updateFishbowlGameState(
+        {
+          round: newFishbowlRound
+        },
+        {
+          displayName: "Fishbowl global screen",
+          playerId: "GLOBAL_SCREEN" as PlayerId
+        }
+      )
+    );
+  };
+
+  useEffect(() => {
+    if (
+      activeRound === undefined ||
+      activeRound.currentActivePlayer.timer.state !== "running" ||
+      timer.timeFraction < 1
+    ) {
+      return;
+    }
+
+    advanceToNextPlayer();
+  }, [timer]);
+}


### PR DESCRIPTION
This pull request introduces enhancements to the Fishbowl game frontend, focusing on improving UI alignment, refining gameplay text, adding player advancement logic, and handling error scenarios. The most significant changes include the addition of a `useAdvancePlayer` hook to manage player transitions, updates to UI components for better alignment, and the introduction of error handling in edge cases.

### Gameplay Logic Enhancements:
* Added a new `useAdvancePlayer` hook in `useAdvancePlayer.ts` to manage the transition to the next player when the timer ends. This includes updating the game state with the next active player and their timer configuration.
* Integrated the `useAdvancePlayer` hook in `RoundInProgress.tsx` to ensure the player automatically advances during gameplay.

### UI Improvements:
* Updated the `DisplayFishbowl` component to center the "Guessing" text using `Flex` alignment properties for better UI consistency.
* Changed the `TimerControl` component's button text to "Start your turn" instead of "Start" for improved clarity.

### Error Handling:
* Added comments in `StartGame.tsx` and `useAdvancePlayer.ts` to indicate potential error scenarios where the active player or next player is undefined, suggesting that these cases should trigger error handling. [[1]](diffhunk://#diff-16ce1347e048b41e607c872424b797bb905c483bdba792dc8c3138c65fdf6e7dR44) [[2]](diffhunk://#diff-08ac4dc213570ae36eebd4507fa4698939be234d1599c4fbfbeec1765f9376e1R1-R102)