### PR TITLE
Fix some isues with state reconciler

### DIFF
--- a/packages/backend/src/gameState/utils/reconcileStates.ts
+++ b/packages/backend/src/gameState/utils/reconcileStates.ts
@@ -63,18 +63,18 @@ function closest(
     // If the previousState has a newer timestamp, we maintain that change and move to the next key
     if (comparedDates === 1) {
       reconciledState[key] = previousState[key];
-      continue;
     }
 
-    // If the timestamps are the same, we need to check the nested object, but only if there's an object to check
+    // If the timestamps are the same or the previousState had an older one, we need to check the nested object, but only if there's an object to check
     if (
       typeof reconciledState[key] !== "object" ||
-      Array.isArray(reconciledState[key])
+      Array.isArray(reconciledState[key]) ||
+      reconciledState[key] == null
     ) {
       continue;
     }
 
-    // We recursively check the nested object starting at this key
+    // We recursively check the nested object starting at this key - we want to use the closest timestamp to the key to decide which state to use
     const { didAcceptChange: reconciledDidAccept, newState } = closest(
       previousState[key] as unknown as NestedTimestamp,
       nextState[key] as unknown as NestedTimestamp,

--- a/packages/games/src/backend/backendRegistry.ts
+++ b/packages/games/src/backend/backendRegistry.ts
@@ -27,8 +27,8 @@ export interface BackendRegisteredGame {
    * The "closest" method will accept changes based on the most updated lastUpdatedAt
    * timestamp, recursively checking through the nested object. Doing a depth first search
    * through the object's keys, it will reconcile state changes based on which object has
-   * the most updated lastUpdatedAt. It will ignore the top level lastUpdatedAt, which is
-   * added by the server automatically.
+   * the most updated lastUpdatedAt timestamp closest to the key being checked. It will prefer
+   * the previous state if both timestamps are identical.
    *
    * See packages/backend/src/gameState/utils/__tests__/reconcileStates.spec.ts for examples.
    */


### PR DESCRIPTION
This pull request enhances the `reconcileStates` utility by refining its logic for handling state reconciliation and expanding its test coverage. The updates improve the handling of nested objects, arrays, and edge cases, ensuring more robust and predictable behavior.

### Test Enhancements:
* Added several new test cases in `reconcileStates.spec.ts` to cover edge cases, including handling arrays, null values, deeply nested objects, identical timestamps, and missing values. These tests ensure the utility behaves correctly in complex scenarios.
* Removed `.only` from a test, ensuring all tests in the suite are executed.

### Logic Improvements:
* Updated the `closest` function in `reconcileStates.ts` to handle `null` values and arrays more effectively and clarified the recursive logic for nested objects. The function now prefers the previous state when timestamps are identical.

### Documentation Updates:
* Updated the documentation in `backendRegistry.ts` to reflect the refined behavior of the "closest" method, emphasizing its preference for the previous state in case of identical timestamps and its focus on the timestamp closest to the key being checked.

### Minor Adjustments:
* Modified the test data in `reconcileStates.spec.ts` to reflect updated timestamps and values for better alignment with new logic.