### PR TITLE
Get a slide confirm to work

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,6 +13,7 @@
     "@dicebear/collection": "^9.2.2",
     "@dicebear/core": "^9.2.2",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/themes": "^3.2.1",
     "@reduxjs/toolkit": "^2.7.0",
     "clsx": "^2.1.1",

--- a/packages/frontend/src/lib/radix/SlideConfirm.module.scss
+++ b/packages/frontend/src/lib/radix/SlideConfirm.module.scss
@@ -1,0 +1,42 @@
+@use "@/styles/variables.scss" as vars;
+
+.container {
+    position: relative;
+    border-radius: 5px;
+    border: 1px solid vars.$black;
+    background: vars.$white;
+}
+
+.sliderTrack {
+    z-index: 2;
+
+    :global(.rt-SliderTrack) {
+        display: none;
+    }
+
+    :global(.rt-SliderThumb) {
+        height: 20px;
+        width: 20px;
+
+        --slider-thumb-box-shadow: 0 0 0 2px #000;
+    }
+}
+
+.text {
+    color: vars.$muted-font;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    left: 0;
+    z-index: 1;
+    user-select: none;
+}
+
+.slideProgress {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background: vars.$green;
+}

--- a/packages/frontend/src/lib/radix/SlideConfirm.tsx
+++ b/packages/frontend/src/lib/radix/SlideConfirm.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { Flex, Slider, Text } from "@radix-ui/themes";
+import { ChevronsRightIcon } from "lucide-react";
+import { useState } from "react";
+import styles from "./SlideConfirm.module.scss";
+
+export interface SlideConfirmProps {
+  confirmText?: string;
+  minimumWidth?: number;
+  onConfirm?: () => void;
+}
+
+export const SlideConfirm = ({ confirmText, onConfirm }: SlideConfirmProps) => {
+  const [value, setValue] = useState(0);
+
+  const onSetValue = ([value]: [number]) => setValue(value);
+
+  const onCommitValue = () => {
+    if (value === 100) {
+      onConfirm?.();
+    }
+
+    setValue(0);
+  };
+
+  const minimumWidth = (confirmText?.length ?? 0) * 20;
+
+  return (
+    <Flex
+      className={styles.container}
+      p="4"
+      style={{ flex: 1, minWidth: `${minimumWidth}px` }}
+    >
+      <Slider
+        className={styles.sliderTrack}
+        onPointerDown={(e) => {
+          // Only allow dragging the thumb, not clicking the track
+          if ((e.target as HTMLElement).matches('[role="slider"]')) {
+            return;
+          }
+
+          e.preventDefault();
+        }}
+        onValueChange={onSetValue}
+        onValueCommit={onCommitValue}
+        value={[value]}
+      />
+      <Flex align="center" className={styles.text} gap="1" justify="center">
+        <ChevronsRightIcon />
+        <Text>{confirmText}</Text>
+        <ChevronsRightIcon />
+      </Flex>
+      <Flex className={styles.slideProgress} style={{ width: `${value}%` }} />
+    </Flex>
+  );
+};

--- a/packages/frontend/src/lib/radix/index.ts
+++ b/packages/frontend/src/lib/radix/index.ts
@@ -3,6 +3,7 @@ export * from "./Dialog";
 export * from "./Flex";
 export * from "./Select";
 export * from "./TextField";
+export * from "./SlideConfirm";
 
 export {
   Badge,

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
@@ -1,10 +1,10 @@
-import { Flex } from "@/lib/radix";
+import { DisplayText, Flex } from "@/lib/radix";
 import { useFishbowlSelector } from "../../store/fishbowlRedux";
 import { selectActiveRound } from "../../store/selectors";
 import { FishbowlTimer } from "../timer/FishbowlTimer";
-import { TimerControl } from "./TimerControl";
 import { ActiveWord } from "./ActiveWord";
 import { SomeoneGotIt } from "./SomeoneGotIt";
+import { TimerControl } from "./TimerControl";
 
 export const ActivePlayer = () => {
   const timer = useFishbowlSelector(
@@ -19,7 +19,10 @@ export const ActivePlayer = () => {
   if (timer.state !== "running") {
     return (
       <Flex align="center" flex="1" gap="2" justify="center">
-        <TimerControl />
+        <Flex direction="column" gap="2">
+          <DisplayText size="7">It's your turn!</DisplayText>
+          <TimerControl />
+        </Flex>
       </Flex>
     );
   }

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/lib/radix";
+import { SlideConfirm } from "@/lib/radix";
 import { FishbowlGameConfiguration } from "../../../../backend";
 import { advanceWord } from "../../stateFunctions/advanceWord";
 import { newRound } from "../../stateFunctions/newRound";
@@ -66,5 +66,7 @@ export const SomeoneGotIt = () => {
     );
   };
 
-  return <Button onClick={onAdvanceWord}>Someone got it!</Button>;
+  return (
+    <SlideConfirm confirmText="Someone got it" onConfirm={onAdvanceWord} />
+  );
 };

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
@@ -5,6 +5,8 @@ import { FishbowlTimer } from "../timer/FishbowlTimer";
 import styles from "./RoundInProgress.module.scss";
 import { WordCelebration } from "./components/WordCelebration";
 import { useAdvancePlayer } from "./hooks/useAdvancePlayer";
+import { TimerState } from "./components/TimerState";
+import { selectPreviousWord } from "../../store/globalScreenSelectors";
 
 export const RoundInProgress = () => {
   useAdvancePlayer();
@@ -12,33 +14,52 @@ export const RoundInProgress = () => {
   const activeRound = useFishbowlSelector(
     (s) => s.gameStateSlice.gameState?.round
   );
+  const previousWord = useFishbowlSelector(selectPreviousWord);
 
   if (activeRound === undefined) {
     return;
   }
 
+  const displayWordsToGo = () => {
+    const wordsToGo = activeRound.remainingWords.length;
+
+    if (wordsToGo === 0) {
+      return "Last word";
+    }
+
+    return `${wordsToGo} word${wordsToGo === 1 ? "" : "s"} to go`;
+  };
+
   return (
     <Flex align="center" flex="1" gap="9" justify="center">
       <WordCelebration />
       <Flex direction="column" gap="3">
-        <Flex align="center" className={styles.activePlayer} gap="5" p="5">
-          <PlayerIcon
-            dimension={100}
-            name={activeRound.currentActivePlayer.player.displayName}
-          />
-          <DisplayText size="9" weight="bold">
-            {activeRound.currentActivePlayer.player.displayName}
-          </DisplayText>
+        <Flex align="center" gap="3">
+          <Flex align="center" className={styles.activePlayer} gap="5" p="5">
+            <PlayerIcon
+              dimension={100}
+              name={activeRound.currentActivePlayer.player.displayName}
+            />
+            <DisplayText size="9" weight="bold">
+              {activeRound.currentActivePlayer.player.displayName}
+            </DisplayText>
+            <TimerState />
+          </Flex>
         </Flex>
         <Flex align="center" gap="4">
           <DisplayText size="7" weight="bold">
             Round {activeRound.roundNumber}
           </DisplayText>
-          <DisplayText size="7">
-            {activeRound.remainingWords.length} word
-            {activeRound.remainingWords.length === 1 ? "" : "s"} to go
-          </DisplayText>
+          <DisplayText size="7">{displayWordsToGo()}</DisplayText>
         </Flex>
+        {previousWord !== undefined && (
+          <Flex align="center" gap="4">
+            <DisplayText size="7" weight="bold">
+              Previous
+            </DisplayText>
+            <DisplayText size="7">{previousWord}</DisplayText>
+          </Flex>
+        )}
       </Flex>
       <FishbowlTimer size={250} timer={activeRound.currentActivePlayer.timer} />
     </Flex>

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/TimerState.module.scss
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/TimerState.module.scss
@@ -1,0 +1,14 @@
+@use "@/styles/variables.scss" as vars;
+
+.loader {
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/TimerState.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/TimerState.tsx
@@ -1,0 +1,17 @@
+import { CircleStop, LoaderCircle } from "lucide-react";
+import { useFishbowlSelector } from "../../../store/fishbowlRedux";
+import styles from "./TimerState.module.scss";
+
+export const TimerState = () => {
+  const timerState = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round?.currentActivePlayer.timer.state
+  );
+
+  if (timerState === "paused") {
+    return <LoaderCircle className={styles.loader} color="orange" size={70} />;
+  }
+
+  if (timerState === "stopped") {
+    return <CircleStop color="red" size={70} />;
+  }
+};

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsx
@@ -34,6 +34,10 @@ export const WordCelebration = () => {
     tweenDuration: 700
   };
 
+  if (activeRound?.correctGuesses.length === 0) {
+    return;
+  }
+
   return (
     <>
       <Confetti

--- a/packages/games/src/frontend/fishbowl/store/globalScreenSelectors.ts
+++ b/packages/games/src/frontend/fishbowl/store/globalScreenSelectors.ts
@@ -55,3 +55,17 @@ export const selectCurrentWordContribution = createSelector(
     };
   }
 );
+
+export const selectPreviousWord = createSelector(
+  [
+    (state: FishbowlReduxState) =>
+      state.gameStateSlice.gameState?.round?.correctGuesses
+  ],
+  (correctGuesses) => {
+    if (correctGuesses === undefined) {
+      return;
+    }
+
+    return correctGuesses[correctGuesses.length - 1]?.guess;
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,6 +2885,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-collection@npm:1.1.7":
+  version: 1.1.7
+  resolution: "@radix-ui/react-collection@npm:1.1.7"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fa321a7300095508491f75414f02b243f0c3f179dc0728cfd115e2ea9f6f48f1516532b59f526d9ac81bbab63cd98a052074b4703ec0b9428fac945ebabec5fd
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-compose-refs@npm:1.1.2":
   version: 1.1.2
   resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
@@ -3402,6 +3424,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-primitive@npm:2.1.3":
+  version: 2.1.3
+  resolution: "@radix-ui/react-primitive@npm:2.1.3"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/fdff9b84913bb4172ef6d3af7442fca5f9bba5f2709cba08950071f819d7057aec3a4a2d9ef44cf9cbfb8014d02573c6884a04cff175895823aaef809ebdb034
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-progress@npm:1.1.4":
   version: 1.1.4
   resolution: "@radix-ui/react-progress@npm:1.1.4"
@@ -3591,6 +3632,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-slider@npm:^1.3.5":
+  version: 1.3.5
+  resolution: "@radix-ui/react-slider@npm:1.3.5"
+  dependencies:
+    "@radix-ui/number": "npm:1.1.1"
+    "@radix-ui/primitive": "npm:1.1.2"
+    "@radix-ui/react-collection": "npm:1.1.7"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-direction": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+    "@radix-ui/react-use-previous": "npm:1.1.1"
+    "@radix-ui/react-use-size": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/2f5f37f953d78ac02ed74120afe76badf3a7d0e19036f4de6cdeda38220718a1d5113ffc2f43e0b3de73e14564cae9a09d1968ee3f9641625849d126a036717f
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-slot@npm:1.2.0":
   version: 1.2.0
   resolution: "@radix-ui/react-slot@npm:1.2.0"
@@ -3603,6 +3673,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/f1455f36479e87a0a2254fc2e2b2aba6740d1fbcada949071210bf2a009a031ad508ac01b544bce96337bcca82f49531b46c71615141a5985aaa11ae69b967b1
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@radix-ui/react-slot@npm:1.2.3"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/5913aa0d760f505905779515e4b1f0f71a422350f077cc8d26d1aafe53c97f177fec0e6d7fbbb50d8b5e498aa9df9f707ca75ae3801540c283b26b0136138eef
   languageName: node
   linkType: hard
 
@@ -3962,7 +4047,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10c0/5c8b4156147befd6acdcb58cd4a228cf5f4f3cd866071858103951238ba90e041bda7cdd92941b9f10734fa5c789793b3c619b0b164bd638ea8cd55771910ada
+  checksum: 10c0/7d6348520c73d7baa700582b3460b8b31b459a52fe14b97fcafd33806929556b50b28fd1d017aa17412649ea1c19b1af10cb089587722b9c1ef811850ad34a6e
   languageName: node
   linkType: hard
 
@@ -4093,6 +4178,7 @@ __metadata:
     "@dicebear/core": "npm:^9.2.2"
     "@jest/globals": "npm:^29.7.0"
     "@radix-ui/react-icons": "npm:^1.3.2"
+    "@radix-ui/react-slider": "npm:^1.3.5"
     "@radix-ui/themes": "npm:^3.2.1"
     "@reduxjs/toolkit": "npm:^2.7.0"
     "@testing-library/jest-dom": "npm:^6.6.3"


### PR DESCRIPTION
This pull request introduces the `SlideConfirm` component for slider-based confirmations, integrates it into the Fishbowl game UI, and enhances the game's global screen with new features like a `TimerState` indicator and previous word display. Additionally, minor refactoring and styling updates are included.

### New Component: `SlideConfirm`

* Added `SlideConfirm` component, which uses a slider for confirmation actions. It includes customizable text, a progress indicator, and a callback for when the slider reaches 100%. (`packages/frontend/src/lib/radix/SlideConfirm.tsx`, `packages/frontend/src/lib/radix/SlideConfirm.module.scss`, [[1]](diffhunk://#diff-43adc6e193f95060af4f2aa6748b19899a53338e503d19067282c88c033fe1baR1-R55) [[2]](diffhunk://#diff-2aece3ab7d11e57e5569858098ec83b1258734623c10759cce26aa87f7507285R1-R42)
* Exported `SlideConfirm` from the Radix library index. (`packages/frontend/src/lib/radix/index.ts`, [packages/frontend/src/lib/radix/index.tsR6](diffhunk://#diff-489341fc7d83449099663955ca24ca82e38b6ff45ff75c6da0a1974519aac6aaR6))

### Integration into Fishbowl Game

* Replaced the "Someone got it!" button with the `SlideConfirm` component in the `SomeoneGotIt` component. (`packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx`, [[1]](diffhunk://#diff-39b540bd4e59e539fe9c11de1d23d28ecfacd97683d6580b276ef79c1b5baba6L1-R1) [[2]](diffhunk://#diff-39b540bd4e59e539fe9c11de1d23d28ecfacd97683d6580b276ef79c1b5baba6L69-R71)
* Updated the `ActivePlayer` component to display a message ("It's your turn!") when the timer is not running. (`packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx`, [packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsxR22-R26](diffhunk://#diff-491c34f4e8e502f1bedba080c0ec6f5e0f1ed69df1b12d7f83cc6d7308686688R22-R26))

### Enhancements to Global Screen

* Added a `TimerState` component to visually indicate the timer's state (paused or stopped) with animations and icons. (`packages/games/src/frontend/fishbowl/components/globalScreen/components/TimerState.tsx`, `packages/games/src/frontend/fishbowl/components/globalScreen/components/TimerState.module.scss`, [[1]](diffhunk://#diff-48fe2747b8916a6d84e7db72559a8f81fd3f4d77f7e1f92afbaaf3b691348840R1-R17) [[2]](diffhunk://#diff-9d9fdca2dcead96b6b9a865fb1c66f88b357d3161b49b47fa6ba6c4bacd668d5R1-R14)
* Modified the `RoundInProgress` component to display the previous word and a dynamic "words to go" message. (`packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx`, [[1]](diffhunk://#diff-5999690626d64c4fac20f59d15141f3e9e02f67b0a93eb94166ab31781e835edR8-R37) [[2]](diffhunk://#diff-5999690626d64c4fac20f59d15141f3e9e02f67b0a93eb94166ab31781e835edR46-R62)
* Added a new selector, `selectPreviousWord`, to retrieve the last correctly guessed word. (`packages/games/src/frontend/fishbowl/store/globalScreenSelectors.ts`, [packages/games/src/frontend/fishbowl/store/globalScreenSelectors.tsR58-R71](diffhunk://#diff-5e1403670b981019e7f43ac111009eadc327e91c6445d6e635e0f978236749d2R58-R71))

### Minor Improvements

* Prevented the `WordCelebration` component from rendering when there are no correct guesses. (`packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsx`, [packages/games/src/frontend/fishbowl/components/globalScreen/components/WordCelebration.tsxR37-R40](diffhunk://#diff-3a55b75f8732ea05efcaee52d9a7d0c2253ae61ef9b6b8a656c2b06260652a35R37-R40))
* Updated `package.json` to include the `@radix-ui/react-slider` dependency. (`packages/frontend/package.json`, [packages/frontend/package.jsonR16](diffhunk://#diff-8571ecd91584b00015b23695d3a6a164282636bb47bfbe46dca243bf9b4db773R16))