### PR TITLE
Fix reconciler bug and display guesses

### DIFF
--- a/packages/backend/src/gameState/ticker/gameStateTicker.service.ts
+++ b/packages/backend/src/gameState/ticker/gameStateTicker.service.ts
@@ -37,9 +37,6 @@ export class GameStateTicker {
         return;
       }
 
-      this.logger.log(
-        `Ticking on ${new Date().toLocaleString()} for ${gamesInFlight.length} games`
-      );
       for (const game of gamesInFlight) {
         this.tickGame(
           this.prismaService.converterService.convertGameState(

--- a/packages/backend/src/gameState/utils/__tests__/reconcileStates.spec.ts
+++ b/packages/backend/src/gameState/utils/__tests__/reconcileStates.spec.ts
@@ -556,4 +556,175 @@ describe("reconcileStates", () => {
     );
     expect(reconciledState.newState).toEqual(previousState);
   });
+
+  it("should reconcile deeply nested objects", () => {
+    const previousState = {
+      lastUpdatedAt: "2025-05-13",
+      "some-player-id-1": {
+        "some-round-number-1": {
+          lastUpdatedAt: "2025-05-13",
+          value: "A"
+        },
+        "some-round-number-2": {
+          lastUpdatedAt: "2025-05-13",
+          value: "A"
+        }
+      },
+      "some-player-id-2": {
+        "some-round-number-1": {
+          lastUpdatedAt: "2025-05-13",
+          value: "B"
+        },
+        "some-round-number-2": {
+          lastUpdatedAt: "2025-05-13",
+          value: "B"
+        }
+      }
+    };
+    const nextState = {
+      lastUpdatedAt: "2025-05-13",
+      "some-player-id-1": {
+        "some-round-number-1": {
+          lastUpdatedAt: "2025-05-13",
+          value: "A"
+        },
+        "some-round-number-2": {
+          lastUpdatedAt: "2025-05-14",
+          value: "B"
+        }
+      },
+      "some-player-id-2": {
+        "some-round-number-1": {
+          lastUpdatedAt: "2025-05-13",
+          value: "B"
+        },
+        "some-round-number-2": {
+          lastUpdatedAt: "2025-05-13",
+          value: "B"
+        }
+      }
+    };
+
+    const reconciledState = reconcileStates(
+      previousState,
+      nextState,
+      "closest"
+    );
+    expect(reconciledState.newState).toEqual(nextState);
+  });
+
+  it("should reconcile deeply nested objects with partial updates", () => {
+    const previousState = {
+      gameState: {
+        playerGuesses: {
+          "some-player-id-1": {
+            "some-round-number-1": {
+              lastUpdatedAt: "2025-05-13",
+              value: "A"
+            },
+            "some-round-number-2": {
+              lastUpdatedAt: "2025-05-13",
+              value: "A"
+            }
+          },
+          "some-player-id-2": {
+            "some-round-number-1": {
+              lastUpdatedAt: "2025-05-13",
+              value: "B"
+            },
+            "some-round-number-2": {
+              lastUpdatedAt: "2025-05-13",
+              value: "B"
+            }
+          }
+        }
+      },
+      lastUpdatedAt: "2025-05-13"
+    };
+    const nextState = {
+      gameState: {
+        playerGuesses: {
+          "some-player-id-1": {
+            "some-round-number-2": {
+              lastUpdatedAt: "2025-05-14",
+              value: "B"
+            }
+          }
+        }
+      },
+      lastUpdatedAt: "2025-05-13"
+    };
+
+    const reconciledState = reconcileStates(
+      previousState,
+      nextState,
+      "closest"
+    );
+
+    expect(reconciledState.didAcceptChange).toBe(true);
+    expect(reconciledState.newState).toEqual({
+      gameState: {
+        playerGuesses: {
+          "some-player-id-1": {
+            "some-round-number-1": {
+              lastUpdatedAt: "2025-05-13",
+              value: "A"
+            },
+            "some-round-number-2": {
+              lastUpdatedAt: "2025-05-14",
+              value: "B"
+            }
+          },
+          "some-player-id-2": {
+            "some-round-number-1": {
+              lastUpdatedAt: "2025-05-13",
+              value: "B"
+            },
+            "some-round-number-2": {
+              lastUpdatedAt: "2025-05-13",
+              value: "B"
+            }
+          }
+        }
+      },
+      lastUpdatedAt: "2025-05-13"
+    });
+  });
+
+  it("should reconcile deeply nested objects with partial updates, with new keys", () => {
+    const previousState = {
+      lastUpdatedAt: "2025-05-13",
+      playerGuesses: {}
+    };
+    const nextState = {
+      lastUpdatedAt: "2025-05-13",
+      playerGuesses: {
+        "some-player-id-1": {
+          "some-round-number-1": {
+            lastUpdatedAt: "2025-05-13",
+            value: "A"
+          }
+        }
+      }
+    };
+
+    const reconciledState = reconcileStates(
+      previousState,
+      nextState,
+      "closest"
+    );
+
+    expect(reconciledState.didAcceptChange).toBe(true);
+    expect(reconciledState.newState).toEqual({
+      lastUpdatedAt: "2025-05-13",
+      playerGuesses: {
+        "some-player-id-1": {
+          "some-round-number-1": {
+            lastUpdatedAt: "2025-05-13",
+            value: "A"
+          }
+        }
+      }
+    });
+  });
 });

--- a/packages/backend/src/gameState/utils/reconcileStates.ts
+++ b/packages/backend/src/gameState/utils/reconcileStates.ts
@@ -53,8 +53,11 @@ function closest(
       nextState[key]?.lastUpdatedAt
     );
 
-    // If the nextState has a newer timestamp, we accept the change and move to the next key
-    if (comparedDates === -1) {
+    // If the nextState has a newer timestamp, or has values the previous state does not have, we accept the change and move to the next key
+    if (
+      comparedDates === -1 ||
+      (reconciledState[key] === undefined && nextState[key] !== undefined)
+    ) {
       didAcceptChange = true;
       reconciledState[key] = nextState[key];
       continue;

--- a/packages/frontend/src/lib/radix/SlideConfirm.module.scss
+++ b/packages/frontend/src/lib/radix/SlideConfirm.module.scss
@@ -38,5 +38,12 @@
     top: 0;
     left: 0;
     bottom: 0;
+}
+
+.green {
     background: vars.$green;
+}
+
+.red {
+    background: vars.$red;
 }

--- a/packages/frontend/src/lib/radix/SlideConfirm.tsx
+++ b/packages/frontend/src/lib/radix/SlideConfirm.tsx
@@ -4,14 +4,20 @@ import { Flex, Slider, Text } from "@radix-ui/themes";
 import { ChevronsRightIcon } from "lucide-react";
 import { useState } from "react";
 import styles from "./SlideConfirm.module.scss";
+import clsx from "clsx";
 
 export interface SlideConfirmProps {
   confirmText?: string;
   minimumWidth?: number;
   onConfirm?: () => void;
+  slideColor?: "green" | "red";
 }
 
-export const SlideConfirm = ({ confirmText, onConfirm }: SlideConfirmProps) => {
+export const SlideConfirm = ({
+  confirmText,
+  onConfirm,
+  slideColor
+}: SlideConfirmProps) => {
   const [value, setValue] = useState(0);
 
   const onSetValue = ([value]: [number]) => setValue(value);
@@ -51,7 +57,14 @@ export const SlideConfirm = ({ confirmText, onConfirm }: SlideConfirmProps) => {
         <Text>{confirmText}</Text>
         <ChevronsRightIcon />
       </Flex>
-      <Flex className={styles.slideProgress} style={{ width: `${value}%` }} />
+      <Flex
+        className={clsx(styles.slideProgress, {
+          [styles.green ?? ""]:
+            slideColor === undefined || slideColor === "green",
+          [styles.red ?? ""]: slideColor === "red"
+        })}
+        style={{ width: `${value}%` }}
+      />
     </Flex>
   );
 };

--- a/packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx
+++ b/packages/games/src/frontend/fishbowl/DisplayFishbowl.tsx
@@ -3,6 +3,7 @@ import { useFishbowlSelector } from "./store/fishbowlRedux";
 import { ContributeWords } from "./components/ContributeWords";
 import { currentPhaseSelector } from "./store/sharedSelectors";
 import { ActivePlayer } from "./components/activePlayer/ActivePlayer";
+import { GuessingPlayer } from "./components/guessingPlayer/GuessingPlayer";
 
 export const DisplayFishbowl = () => {
   const phase = useFishbowlSelector(currentPhaseSelector);
@@ -29,7 +30,7 @@ export const DisplayFishbowl = () => {
 
   return (
     <Flex align="center" flex="1" justify="center">
-      Guessing
+      <GuessingPlayer />
     </Flex>
   );
 };

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/ActivePlayer.tsx
@@ -35,7 +35,7 @@ export const ActivePlayer = () => {
           <FishbowlTimer timer={timer} />
         </Flex>
         <Flex align="center" gap="2">
-          <SomeoneGotIt />
+          <SomeoneGotIt timer={timer} />
           <TimerControl />
         </Flex>
       </Flex>

--- a/packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx
+++ b/packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx
@@ -1,5 +1,8 @@
 import { SlideConfirm } from "@/lib/radix";
-import { FishbowlGameConfiguration } from "../../../../backend";
+import {
+  FishbowlActiveTracker,
+  FishbowlGameConfiguration
+} from "../../../../backend";
 import { advanceWord } from "../../stateFunctions/advanceWord";
 import { newRound } from "../../stateFunctions/newRound";
 import {
@@ -8,9 +11,12 @@ import {
   useFishbowlSelector
 } from "../../store/fishbowlRedux";
 import { selectActiveRound, selectFishbowlPlayer } from "../../store/selectors";
+import { useTimer } from "../../hooks/useTimer";
+import { LOW_TIME_THRESHOLD } from "../timer/FishbowlTimer";
 
-export const SomeoneGotIt = () => {
+export const SomeoneGotIt = ({ timer }: { timer: FishbowlActiveTracker }) => {
   const dispatch = useFishbowlDispatch();
+  const { timeFraction } = useTimer(timer);
 
   const activePlayer = useFishbowlSelector(selectFishbowlPlayer);
   const activeRound = useFishbowlSelector(selectActiveRound);
@@ -67,6 +73,10 @@ export const SomeoneGotIt = () => {
   };
 
   return (
-    <SlideConfirm confirmText="Someone got it" onConfirm={onAdvanceWord} />
+    <SlideConfirm
+      confirmText="Someone got it"
+      onConfirm={onAdvanceWord}
+      slideColor={timeFraction <= LOW_TIME_THRESHOLD ? "green" : "red"}
+    />
   );
 };

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx
@@ -6,7 +6,10 @@ import styles from "./RoundInProgress.module.scss";
 import { WordCelebration } from "./components/WordCelebration";
 import { useAdvancePlayer } from "./hooks/useAdvancePlayer";
 import { TimerState } from "./components/TimerState";
-import { selectPreviousWord } from "../../store/globalScreenSelectors";
+import {
+  selectCurrentWordContribution,
+  selectPreviousWord
+} from "../../store/globalScreenSelectors";
 
 export const RoundInProgress = () => {
   useAdvancePlayer();
@@ -14,6 +17,7 @@ export const RoundInProgress = () => {
   const activeRound = useFishbowlSelector(
     (s) => s.gameStateSlice.gameState?.round
   );
+  const wordCount = useFishbowlSelector(selectCurrentWordContribution);
   const previousWord = useFishbowlSelector(selectPreviousWord);
 
   if (activeRound === undefined) {
@@ -21,13 +25,13 @@ export const RoundInProgress = () => {
   }
 
   const displayWordsToGo = () => {
-    const wordsToGo = activeRound.remainingWords.length;
+    const wordsToGo = activeRound.remainingWords.length + 1;
 
     if (wordsToGo === 0) {
       return "Last word";
     }
 
-    return `${wordsToGo} word${wordsToGo === 1 ? "" : "s"} to go`;
+    return `${wordsToGo} / ${wordCount?.currentWordCount ?? 0} word${wordsToGo === 1 ? "" : "s"} to go`;
   };
 
   return (

--- a/packages/games/src/frontend/fishbowl/components/guessingPlayer/GuessingPlayer.module.scss
+++ b/packages/games/src/frontend/fishbowl/components/guessingPlayer/GuessingPlayer.module.scss
@@ -1,0 +1,21 @@
+@use "@/styles/variables.scss" as vars;
+
+.player {
+    border-radius: 5px;
+    background: vars.$white;
+    border: 1px solid vars.$black;
+}
+
+.previousGuessContainer {
+    max-height: 150px;
+    height: 150px;
+    overflow-y: auto;
+    border: 1px solid vars.$border-color;
+    border-radius: 5px;
+    background: vars.$white;
+}
+
+.correctGuess {
+    background: vars.$green;
+    color: vars.$white;
+}

--- a/packages/games/src/frontend/fishbowl/components/guessingPlayer/GuessingPlayer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/guessingPlayer/GuessingPlayer.tsx
@@ -1,0 +1,69 @@
+import { PlayerIcon } from "@/components/player/PlayerIcon";
+import { DisplayText, Flex } from "@/lib/radix";
+import { useFishbowlSelector } from "../../store/fishbowlRedux";
+import { selectPlayerGuesses } from "../../store/selectors";
+import styles from "./GuessingPlayer.module.scss";
+import { SubmitGuess } from "./SubmitGuess";
+import clsx from "clsx";
+
+export const GuessingPlayer = () => {
+  const activePlayer = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round?.currentActivePlayer
+  );
+  const guesses = useFishbowlSelector(selectPlayerGuesses);
+  const correctWord = useFishbowlSelector(
+    (state) => state.gameStateSlice.gameState?.round?.currentActiveWord
+  );
+
+  if (activePlayer === undefined) {
+    return;
+  }
+
+  if (activePlayer.timer.state !== "running") {
+    return (
+      <Flex align="center" gap="2" p="5">
+        <DisplayText size="5">Waiting for</DisplayText>
+        <Flex align="center" className={styles.player} gap="2" p="2">
+          <PlayerIcon dimension={25} name={activePlayer.player.displayName} />
+          <DisplayText size="5">{activePlayer.player.displayName}</DisplayText>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  const reversedGuesses = guesses?.guesses.slice().reverse();
+
+  const maybeRenderPreviousGuesses = () => {
+    if (reversedGuesses === undefined || reversedGuesses.length === 0) {
+      return (
+        <Flex align="center" flex="1" justify="center">
+          <DisplayText>No guesses yet</DisplayText>
+        </Flex>
+      );
+    }
+
+    return reversedGuesses.map((guess) => (
+      <Flex
+        align="center"
+        className={clsx({
+          [styles.correctGuess ?? ""]: correctWord?.word === guess.guess
+        })}
+        flex="1"
+        key={guess.timestamp}
+        px="2"
+        py="1"
+      >
+        <DisplayText key={guess.timestamp}>{guess.guess}</DisplayText>
+      </Flex>
+    ));
+  };
+
+  return (
+    <Flex direction="column" gap="2">
+      <SubmitGuess />
+      <Flex className={styles.previousGuessContainer} direction="column">
+        {maybeRenderPreviousGuesses()}
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/fishbowl/components/guessingPlayer/SubmitGuess.tsx
+++ b/packages/games/src/frontend/fishbowl/components/guessingPlayer/SubmitGuess.tsx
@@ -1,0 +1,71 @@
+import { Button, Flex, TextField } from "@/lib/radix";
+import { useState } from "react";
+import {
+  updateFishbowlGameState,
+  useFishbowlDispatch,
+  useFishbowlSelector
+} from "../../store/fishbowlRedux";
+import { selectNewPlayerGuess } from "../../store/selectors";
+import {
+  FishbowlAllPlayerGuesses,
+  FishbowlSingleGuess,
+  FishbowlSinglePlayerGuesses
+} from "../../../../backend";
+
+export const SubmitGuess = () => {
+  const dispatch = useFishbowlDispatch();
+  const maybeNewGuessDetails = useFishbowlSelector(selectNewPlayerGuess);
+
+  const [guess, setGuess] = useState("");
+
+  const onGuess = () => {
+    const sanitizedGuess = guess.trim();
+    if (sanitizedGuess.length === 0 || maybeNewGuessDetails === undefined) {
+      return;
+    }
+
+    const newGuess: FishbowlSingleGuess = {
+      currentActivePlayer: maybeNewGuessDetails.activePlayer,
+      guess: sanitizedGuess,
+      guessingPlayer: maybeNewGuessDetails.player,
+      roundNumber: maybeNewGuessDetails.roundNumber,
+      timestamp: new Date().toISOString()
+    };
+
+    const existingGuesses =
+      maybeNewGuessDetails.currentRoundGuesses?.guesses ?? [];
+
+    const updatedRoundGuesses: FishbowlSinglePlayerGuesses = {
+      guesses: existingGuesses.concat(newGuess),
+      lastUpdatedAt: new Date().toISOString(),
+      player: maybeNewGuessDetails.player
+    };
+
+    // Note: the backend state reconciler will handle the partial updates for us
+    const updatedPlayerGuesses: FishbowlAllPlayerGuesses = {
+      [maybeNewGuessDetails.player.playerId]: {
+        [maybeNewGuessDetails.roundNumber]: updatedRoundGuesses
+      }
+    };
+
+    dispatch(
+      updateFishbowlGameState(
+        { playerGuesses: updatedPlayerGuesses },
+        maybeNewGuessDetails.player
+      )
+    );
+
+    setGuess("");
+  };
+
+  return (
+    <Flex align="center" gap="2">
+      <TextField
+        onChange={(value) => setGuess(value)}
+        style={{ width: "50vw" }}
+        value={guess}
+      />
+      <Button onClick={onGuess}>Guess</Button>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.tsx
+++ b/packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.tsx
@@ -23,6 +23,8 @@ function calculateClockPointer(timeFraction: number, size: number) {
   return `M ${centerX(size)} ${centerY(size)} L ${endX} ${endY}`;
 }
 
+export const LOW_TIME_THRESHOLD = 0.8;
+
 export const FishbowlTimer = ({
   timer,
   size
@@ -44,8 +46,8 @@ export const FishbowlTimer = ({
         <svg height={finalSize} width={finalSize}>
           <circle
             className={clsx(styles.clock, {
-              [styles.greenTime ?? ""]: timeFraction <= 0.8,
-              [styles.lowTime ?? ""]: timeFraction > 0.8
+              [styles.greenTime ?? ""]: timeFraction <= LOW_TIME_THRESHOLD,
+              [styles.lowTime ?? ""]: timeFraction > LOW_TIME_THRESHOLD
             })}
             cx={centerX(finalSize)}
             cy={centerY(finalSize)}

--- a/packages/games/src/frontend/fishbowl/store/selectors.ts
+++ b/packages/games/src/frontend/fishbowl/store/selectors.ts
@@ -60,3 +60,43 @@ export const selectActiveRound = createSelector(
     return round;
   }
 );
+
+export const selectPlayerGuesses = createSelector(
+  [
+    (state: FishbowlReduxState) => state.playerSlice.player,
+    (state: FishbowlReduxState) =>
+      state.gameStateSlice.gameState?.round?.roundNumber,
+    (state: FishbowlReduxState) => state.gameStateSlice.gameState?.playerGuesses
+  ],
+  (player, roundNumber, guesses) => {
+    if (
+      player === undefined ||
+      roundNumber === undefined ||
+      guesses === undefined
+    ) {
+      return;
+    }
+
+    return guesses[player.playerId]?.[roundNumber];
+  }
+);
+
+export const selectNewPlayerGuess = createSelector(
+  [
+    (state: FishbowlReduxState) => state.playerSlice.player,
+    (state: FishbowlReduxState) => state.gameStateSlice.gameState?.round,
+    (state: FishbowlReduxState) => state.gameStateSlice.gameState?.playerGuesses
+  ],
+  (player, round, guesses) => {
+    if (player === undefined || round === undefined || guesses === undefined) {
+      return;
+    }
+
+    return {
+      activePlayer: round.currentActivePlayer.player,
+      currentRoundGuesses: guesses[player.playerId]?.[round.roundNumber],
+      player,
+      roundNumber: round.roundNumber
+    };
+  }
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4047,7 +4047,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10c0/7d6348520c73d7baa700582b3460b8b31b459a52fe14b97fcafd33806929556b50b28fd1d017aa17412649ea1c19b1af10cb089587722b9c1ef811850ad34a6e
+  checksum: 10c0/5c8b4156147befd6acdcb58cd4a228cf5f4f3cd866071858103951238ba90e041bda7cdd92941b9f10734fa5c789793b3c619b0b164bd638ea8cd55771910ada
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces several updates across the backend and frontend to enhance game state handling, improve reconciliation logic, and add new UI features for the Fishbowl game. The changes include improvements to state reconciliation, new features for the guessing player interface, and updates to the game's timer and progress indicators.

### Backend Updates
* **State Reconciliation Enhancements**:
  - Updated the `closest` function to handle cases where `nextState` has values that `previousState` does not, ensuring partial updates are accepted. (`packages/backend/src/gameState/utils/reconcileStates.ts`)
  - Added comprehensive unit tests to validate reconciliation of deeply nested objects, partial updates, and new keys. (`packages/backend/src/gameState/utils/__tests__/reconcileStates.spec.ts`)

* **Logging Changes**:
  - Removed verbose logging from the `GameStateTicker` to reduce noise in logs. (`packages/backend/src/gameState/ticker/gameStateTicker.service.ts`)

### Frontend Updates
* **Fishbowl Game Enhancements**:
  - Introduced a new `GuessingPlayer` component to display the current player's guesses and allow new guesses to be submitted. (`packages/games/src/frontend/fishbowl/components/guessingPlayer/GuessingPlayer.tsx`, `SubmitGuess.tsx`, `GuessingPlayer.module.scss`) [[1]](diffhunk://#diff-f7d9409d4391d4ad510ed0fedaf141cad8161406157aaa0ebea6ad05f35683d8R1-R69) [[2]](diffhunk://#diff-67151b6c8c530756d343627d7eb474d726fa408ed33d3615f468568df76a9811R1-R71) [[3]](diffhunk://#diff-0b9071bd4a85166c4bede8b25a1593dbc5e84f532d1b96e503589cb87292a23eR1-R21)
  - Updated the `SomeoneGotIt` component to dynamically change the slider's color based on the timer's state. (`packages/games/src/frontend/fishbowl/components/activePlayer/SomeoneGotIt.tsx`)

* **Timer and Progress Updates**:
  - Added a `LOW_TIME_THRESHOLD` constant to centralize the logic for low-time warnings and updated the timer's visual indicators accordingly. (`packages/games/src/frontend/fishbowl/components/timer/FishbowlTimer.tsx`) [[1]](diffhunk://#diff-69da7a872022d0020c9600c3da4c8be48ddef6e5072ac219cebf4748033cf121R26-R27) [[2]](diffhunk://#diff-69da7a872022d0020c9600c3da4c8be48ddef6e5072ac219cebf4748033cf121L47-R50)
  - Enhanced the progress display during a round to show the total word count alongside remaining words. (`packages/games/src/frontend/fishbowl/components/globalScreen/RoundInProgress.tsx`)

* **Styling Updates**:
  - Added new styles for the guessing player interface, including correct guess highlighting and a scrollable container for previous guesses. (`packages/games/src/frontend/fishbowl/components/guessingPlayer/GuessingPlayer.module.scss`)
  - Extended `SlideConfirm` to support customizable slider colors (`green` or `red`) for better visual feedback. (`packages/frontend/src/lib/radix/SlideConfirm.tsx`, `SlideConfirm.module.scss`) [[1]](diffhunk://#diff-43adc6e193f95060af4f2aa6748b19899a53338e503d19067282c88c033fe1baR7-R20) [[2]](diffhunk://#diff-43adc6e193f95060af4f2aa6748b19899a53338e503d19067282c88c033fe1baL54-R67) [[3]](diffhunk://#diff-2aece3ab7d11e57e5569858098ec83b1258734623c10759cce26aa87f7507285R41-R49)

### State Management
* **New Selectors**:
  - Added selectors to retrieve player guesses and prepare new guess details for submission. (`packages/games/src/frontend/fishbowl/store/selectors.ts`)

These changes collectively improve the game's functionality, user experience, and maintainability.