### PR TITLE
Update display of words accounting for round + active word

### DIFF
--- a/packages/games/src/backend/fishbowl/fishbowl.ts
+++ b/packages/games/src/backend/fishbowl/fishbowl.ts
@@ -44,6 +44,10 @@ export interface FishbowlSingleGuess {
    */
   currentActivePlayer: PlayerInGame;
   /**
+   * The word that the player was giving clues for when this guess was made.
+   */
+  currentActiveWord: FishbowlWord;
+  /**
    * The actual guess that was made.
    */
   guess: string;

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/ActivePlayerTracker.module.scss
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/ActivePlayerTracker.module.scss
@@ -1,7 +1,31 @@
 @use "@/styles/variables.scss" as vars;
 
 .activePlayer {
-    background: vars.$white;
     border-radius: 5px;
     border: 1px solid vars.$black;
+    position: relative;
+    overflow: hidden;
+}
+
+.content {
+    z-index: 2;
+}
+
+.background {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+}
+
+.whiteBackground {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 0;
+    background: vars.$white;
 }

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/ActivePlayerTracker.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/ActivePlayerTracker.tsx
@@ -3,6 +3,14 @@ import { DisplayText, Flex } from "@/lib/radix";
 import { useFishbowlSelector } from "../../../store/fishbowlRedux";
 import { TimerState } from "./TimerState";
 import styles from "./ActivePlayerTracker.module.scss";
+import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
+
+const hexToRgba = (hex: string, opacity: number) => {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+};
 
 export const ActivePlayerTracker = () => {
   const activeRound = useFishbowlSelector(
@@ -14,8 +22,8 @@ export const ActivePlayerTracker = () => {
   }
 
   return (
-    <Flex align="center" gap="3">
-      <Flex align="center" className={styles.activePlayer} gap="5" p="5">
+    <Flex className={styles.activePlayer} p="5">
+      <Flex align="center" className={styles.content} gap="5">
         <PlayerIcon
           dimension={100}
           name={activeRound.currentActivePlayer.player.displayName}
@@ -25,6 +33,17 @@ export const ActivePlayerTracker = () => {
         </DisplayText>
         <TimerState />
       </Flex>
+
+      <Flex
+        className={styles.background}
+        style={{
+          background: hexToRgba(
+            getTeamColor(activeRound.currentActivePlayer.player.team ?? 0),
+            0.3
+          )
+        }}
+      />
+      <Flex className={styles.whiteBackground} />
     </Flex>
   );
 };

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/CurrentGuesses.module.scss
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/CurrentGuesses.module.scss
@@ -1,0 +1,5 @@
+@use "@/styles/variables.scss" as vars;
+
+.guesses {
+    overflow: hidden;
+}

--- a/packages/games/src/frontend/fishbowl/components/globalScreen/components/CurrentGuesses.tsx
+++ b/packages/games/src/frontend/fishbowl/components/globalScreen/components/CurrentGuesses.tsx
@@ -1,8 +1,10 @@
 import { DisplayText, Flex } from "@/lib/radix";
+import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
+import { ArrowLeftIcon, ArrowRightIcon } from "lucide-react";
 import { selectTeamWithNames } from "../../../../shared/globalSelectors";
 import { useFishbowlSelector } from "../../../store/fishbowlRedux";
 import { selectGuessesByTeam } from "../../../store/globalScreenSelectors";
-import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
+import styles from "./CurrentGuesses.module.scss";
 
 export const CurrentGuesses = () => {
   const teams = useFishbowlSelector(selectTeamWithNames);
@@ -17,40 +19,53 @@ export const CurrentGuesses = () => {
       {Object.entries(teams).map(([teamNumber, { teamName }]) => {
         const teamGuesses =
           guessesByTeam.guessesByTeam[parseFloat(teamNumber)] ?? [];
+        const isActiveTeam =
+          guessesByTeam.currentActiveTeam === parseFloat(teamNumber);
 
         return (
           <Flex
             direction="column"
             flex="1"
-            gap="5"
+            gap="7"
             p="5"
             style={{ background: getTeamColor(parseFloat(teamNumber)) }}
           >
-            <Flex justify="center">
+            <Flex align="center" gap="2" justify="center" mb="5">
+              {isActiveTeam && <ArrowRightIcon size={30} />}
               <DisplayText size="7" weight="bold">
                 {teamName}
               </DisplayText>
+              {isActiveTeam && <ArrowLeftIcon size={30} />}
             </Flex>
-            {teamGuesses.map((guess) => {
-              if (guess.guess === guessesByTeam.correctGuess) {
+            <Flex className={styles.guesses} direction="column" gap="4">
+              {teamGuesses.map((guess, index) => {
+                if (guess.guess === guessesByTeam.correctGuess) {
+                  return (
+                    <Flex direction="column" gap="2">
+                      <DisplayText color="green" size="7" weight="bold">
+                        {guess.guessingPlayer.displayName} got it!
+                      </DisplayText>
+                    </Flex>
+                  );
+                }
+
+                const opacity = Math.max(0.1, 1 - (index - 4) * 0.15);
+
                 return (
-                  <Flex direction="column" gap="2">
-                    <DisplayText color="green" size="7" weight="bold">
-                      {guess.guessingPlayer.displayName} got it!
+                  <Flex
+                    align="center"
+                    gap="2"
+                    justify="between"
+                    style={{ opacity }}
+                  >
+                    <DisplayText size="8">{guess.guess}</DisplayText>
+                    <DisplayText size="4">
+                      {guess.guessingPlayer.displayName}
                     </DisplayText>
                   </Flex>
                 );
-              }
-
-              return (
-                <Flex gap="2" justify="between">
-                  <DisplayText size="7">{guess.guess}</DisplayText>
-                  <DisplayText size="4">
-                    {guess.guessingPlayer.displayName}
-                  </DisplayText>
-                </Flex>
-              );
-            })}
+              })}
+            </Flex>
           </Flex>
         );
       })}

--- a/packages/games/src/frontend/fishbowl/components/guessingPlayer/SubmitGuess.tsx
+++ b/packages/games/src/frontend/fishbowl/components/guessingPlayer/SubmitGuess.tsx
@@ -23,13 +23,15 @@ export const SubmitGuess = () => {
     if (
       sanitizedGuess.length === 0 ||
       maybeNewGuessDetails === undefined ||
-      maybeNewGuessDetails.player === undefined
+      maybeNewGuessDetails.player === undefined ||
+      maybeNewGuessDetails.currentActiveWord === undefined
     ) {
       return;
     }
 
     const newGuess: FishbowlSingleGuess = {
       currentActivePlayer: maybeNewGuessDetails.activePlayer,
+      currentActiveWord: maybeNewGuessDetails.currentActiveWord,
       guess: sanitizedGuess,
       guessingPlayer: maybeNewGuessDetails.player,
       roundNumber: maybeNewGuessDetails.roundNumber,

--- a/packages/games/src/frontend/fishbowl/stateFunctions/advanceWord.ts
+++ b/packages/games/src/frontend/fishbowl/stateFunctions/advanceWord.ts
@@ -22,6 +22,7 @@ export function advanceWord(
   updatedRound.correctGuesses.push({
     ...activeRound.currentActiveWord,
     currentActivePlayer: activeRound.currentActivePlayer.player,
+    currentActiveWord: activeRound.currentActiveWord,
     guess: activeRound.currentActiveWord.word,
     guessingPlayer: guessingPlayer,
     roundNumber: activeRound.roundNumber,

--- a/packages/games/src/frontend/fishbowl/store/globalScreenSelectors.ts
+++ b/packages/games/src/frontend/fishbowl/store/globalScreenSelectors.ts
@@ -7,6 +7,7 @@ import {
   FishbowlSinglePlayerGuesses
 } from "../../../backend";
 import { FishbowlReduxState } from "./fishbowlRedux";
+import { isEqual } from "lodash-es";
 
 export const selectCurrentWordContribution = createSelector(
   [
@@ -88,10 +89,16 @@ export const selectPreviousWord = createSelector(
 export const selectGuessesByTeam = createSelector(
   [
     (state: FishbowlReduxState) => state.gameStateSlice.gameState?.round,
-    (state: FishbowlReduxState) => state.gameStateSlice.gameState?.playerGuesses
+    (state: FishbowlReduxState) =>
+      state.gameStateSlice.gameState?.playerGuesses,
+    (state: FishbowlReduxState) => state.gameStateSlice.gameState?.round
   ],
-  (round, playerGuesses) => {
-    if (round === undefined || playerGuesses === undefined) {
+  (round, playerGuesses, activeRound) => {
+    if (
+      round === undefined ||
+      playerGuesses === undefined ||
+      activeRound === undefined
+    ) {
       return;
     }
 
@@ -107,8 +114,15 @@ export const selectGuessesByTeam = createSelector(
       }
 
       const playerTeam = guessesInRound.player.team ?? 0;
+      const filteredGuesses = guessesInRound.guesses.filter(
+        (guess) =>
+          guess.currentActivePlayer.playerId ===
+            activeRound.currentActivePlayer.player.playerId &&
+          isEqual(guess.currentActiveWord, activeRound.currentActiveWord)
+      );
+
       guessesByTeam[playerTeam] = (guessesByTeam[playerTeam] ?? []).concat(
-        guessesInRound.guesses
+        filteredGuesses
       );
     });
 

--- a/packages/games/src/frontend/fishbowl/store/selectors.ts
+++ b/packages/games/src/frontend/fishbowl/store/selectors.ts
@@ -95,6 +95,7 @@ export const selectNewPlayerGuess = createSelector(
 
     return {
       activePlayer: round.currentActivePlayer.player,
+      currentActiveWord: round.currentActiveWord,
       currentRoundGuesses: guesses[player.playerId]?.[round.roundNumber],
       player: allPlayers?.find((p) => p.playerId === player.playerId),
       roundNumber: round.roundNumber


### PR DESCRIPTION
This pull request introduces enhancements to the `Fishbowl` game, focusing on improved tracking of guesses, better player and team visualization, and refined state management. Key changes include adding `currentActiveWord` to the guess data structure, updating UI components for better styling and interactivity, and refining selectors to filter guesses more precisely.

### Backend Changes:
* **Enhanced Guess Data Structure:**
  Added `currentActiveWord` to the `FishbowlSingleGuess` interface, enabling tracking of the word being guessed alongside the player details.

### Frontend Changes:
#### UI Enhancements:
* **Active Player Tracker Component (`ActivePlayerTracker.tsx`):**
  - Introduced dynamic background styling based on team color with opacity adjustments.
  - Refactored layout to separate content, background, and white overlay for better visual layering.

* **Current Guesses Component (`CurrentGuesses.tsx`):**
  - Added indicators (arrows) to highlight the active team.
  - Applied opacity adjustments to older guesses for improved readability.

#### State Management:
* **Selectors (`globalScreenSelectors.ts`):**
  - Enhanced `selectGuessesByTeam` to filter guesses based on the active player and word using `lodash-es` for deep comparison.
  - Added `currentActiveWord` to `selectNewPlayerGuess` for more comprehensive state tracking.