### PR TITLE
Fix docker for backend

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 RUN --mount=type=cache,target=/app/.yarn.cache npx turbo prune @resync-games/backend --docker && cp -R .yarn .yarnrc.yml .pnp.cjs tsconfig.json out/ && mv out/full/* out/ && rm -rf out/json && rm -rf out/full
-RUN cp -r packages/games out/packages/games && cp .env out/packages/backend/
+RUN cp -r packages/games out/packages/games && cp -r packages/api out/packages/api && cp .env out/packages/backend/
 
 WORKDIR /app/out
 


### PR DESCRIPTION
This pull request updates the `Dockerfile` to include the `packages/api` directory in the build process. This ensures that the API package is properly copied to the output directory during the Docker image build.

Key change:

* [`packages/backend/Dockerfile`](diffhunk://#diff-abd8897a16a6ff6e946fbdf07d39d89cf558743c5005cd8469172afd1dd5e02eL7-R7): Modified the `RUN` command to include `packages/api` in the output directory (`out/packages/api`) during the build process.