### PR TITLE
Add blog on toxic teams

### DIFF
--- a/blog-post.md
+++ b/blog-post.md
@@ -1,0 +1,42 @@
+<BlogText>
+I've been on a few engineering teams that turned toxic, some over time, and some from the start. While on these teams, I:
+</BlogText>
+
+<BlogText>
+* Felt anxious and stressed, all the time
+* I was not good at compartmentalizing, so I allowed the bad work situation to affect my personal life.
+* Obsessed with the technical work
+* As a defense mechanism against the difficult people situation
+* Fluctuated between anger and sadness
+* I felt disempowered to effect change, which affected my wellbeing differently day to day.
+</BlogText>
+
+<BlogText>
+These were not pleasant experiences, but in retrospect, they shaped who I am today. I've spent a lot of time reflecting on what caused those experiences to turn so sour. So here's what I've got. I believe any of the following will eventually result in a toxic team:
+</BlogText>
+
+<BlogText>
+* A single toxic individual who asserts strong opinions and inserts themselves everywhere
+  * It causes the toxic disease to spread because if I want my opinions heard, I have to compete with this individual, so I inevitably become toxic too.
+* Not enough work to go around
+  * We need to compete with each other for the "good" projects, resulting in tense relationships between people who should be collaborating.
+  * And it results in a lot of downtime, which, given the existing tense relationships, leads to bickering.
+* Visionless management, which is also opinionated
+  * As a motivated team member, I must constantly guess at what management wants us to build, which may or may not align with what our users need.
+  * And when we ask for clarification, we don't get anything actionable or concrete because management does not know what it wants.
+  * However, since management knows what it does not want, it shuts projects down, resulting in a few individuals becoming demotivated as they watch their work crumble.
+  * This inevitably spreads to the rest of the team during the myriad ranting sessions between team members.
+</BlogText>
+
+<BlogText>
+In these circumstances, earned authority engineers will have a tough time turning the ship around. These are complex people issues, and I believe this is exactly what management is paid to deal with. They need to step in and remedy the situation:
+</BlogText>
+
+<BlogText>
+* Toxic individual
+  * A behavior performance conversation, followed by requests for actionable changes, leading to either a change or termination
+* Not enough work to go around
+  * Either working with the team to create new scope, a higher level of ambition given the resourcing, or a reduction in the team's size
+* Visionless management
+  * Either stop having opinions and let the team guide in a bottom-up approach, or come in with a stronger vision - you can't have both
+</BlogText> 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,6 +19,7 @@
     "clsx": "^2.1.1",
     "copy-to-clipboard": "^3.3.3",
     "create-hash": "^1.2.0",
+    "konva": "^9.3.20",
     "lodash-es": "^4.17.21",
     "lucide-react": "^0.501.0",
     "motion": "^12.7.4",

--- a/packages/frontend/src/app/blog/engineering/toxic-teams/page.tsx
+++ b/packages/frontend/src/app/blog/engineering/toxic-teams/page.tsx
@@ -1,0 +1,172 @@
+import { BlogEntry } from "@/components/blog/BlogEntry";
+import { BlogText, PlainBlogText } from "@/lib/resync-components/BlogText";
+
+export default function ToxicTeams() {
+  return (
+    <BlogEntry>
+      <BlogText>
+        I've been on a few engineering teams that turned toxic, some over time,
+        and some from the start. While on these teams, I:
+      </BlogText>
+      <PlainBlogText>
+        <ul>
+          <li>
+            Felt anxious and stressed, all the time
+            <ul>
+              <li>
+                I was not good at compartmentalizing, so I allowed the bad work
+                situation to affect my personal life.
+              </li>
+            </ul>
+          </li>
+          <li>
+            Obsessed with the technical work
+            <ul>
+              <li>
+                As a defense mechanism against the difficult people situation
+              </li>
+            </ul>
+          </li>
+          <li>
+            Fluctuated between anger and sadness
+            <ul>
+              <li>
+                I felt disempowered to effect change, which affected my
+                wellbeing differently day to day.
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </PlainBlogText>
+      <BlogText>
+        These were not pleasant experiences, but in retrospect, they shaped who
+        I am today. I've spent a lot of time reflecting on what caused those
+        experiences to turn so sour. So here's what I've got. I believe any of
+        the following will eventually result in a toxic team:
+      </BlogText>
+      <PlainBlogText>
+        <ul>
+          <li>
+            A single toxic individual who asserts strong opinions and inserts
+            themselves everywhere
+            <ul>
+              <li>
+                It causes the toxic disease to spread because if I want my
+                opinions heard, I have to compete with this individual, so I
+                inevitably become toxic too.
+              </li>
+            </ul>
+          </li>
+          <li>
+            Not enough work to go around
+            <ul>
+              <li>
+                We need to compete with each other for the “good” projects,
+                resulting in tense relationships between people who should be
+                collaborating.
+              </li>
+              <li>
+                And it results in a lot of downtime, which, given the existing
+                tense relationships, leads to bickering.
+              </li>
+            </ul>
+          </li>
+          <li>
+            Visionless management, which is also opinionated
+            <ul>
+              <li>
+                As a motivated team member, I must constantly guess at what
+                management wants us to build, which may or may not align with
+                what our users need.
+              </li>
+              <li>
+                And when we ask for clarification, we don’t get anything
+                actionable or concrete because management does not know what it
+                wants.
+              </li>
+              <li>
+                However, since management knows what it does not want, it shuts
+                projects down, resulting in a few individuals becoming
+                demotivated as they watch their work crumble.
+              </li>
+              <li>
+                This inevitably spreads to the rest of the team during the
+                myriad ranting sessions between team members.
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </PlainBlogText>
+      <BlogText>
+        In these circumstances, earned authority engineers will have a tough
+        time turning the ship around. These are complex people issues, and I
+        believe this is exactly what management is paid to deal with. They need
+        to step in and remedy the situation:
+      </BlogText>
+      <PlainBlogText>
+        <ul>
+          <li>
+            Toxic individual
+            <ul>
+              <li>
+                A behavior performance conversation, followed by requests for
+                actionable changes, leading to either a change or termination
+              </li>
+            </ul>
+          </li>
+          <li>
+            Not enough work to go around
+            <ul>
+              <li>
+                Either working with the team to create new scope, a higher level
+                of ambition given the resourcing, or a reduction in the team’s
+                size
+              </li>
+            </ul>
+          </li>
+          <li>
+            Visionless management
+            <ul>
+              Either stop having opinions and let the team guide in a bottom-up
+              approach, or come in with a stronger vision - you can’t have both
+            </ul>
+          </li>
+        </ul>
+      </PlainBlogText>
+      <PlainBlogText>
+        <ol>
+          <li>
+            <a
+              href="https://news.ycombinator.com/item?id=36882767"
+              target="_blank"
+            >
+              Hacker news: how to build toxic software teams
+            </a>
+          </li>
+          <li>
+            <a href="https://uplevelteam.com/blog/toxic-engineering-culture">
+              Uplevel, 15 symptoms of a toxic engineering culture
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://medium.com/@jameskip/how-toxic-engineering-cultures-undermine-innovation-and-growth-68a79334f4d7"
+              target="_blank"
+            >
+              James Kip, how toxic engineering cultures undermine innovation and
+              growth
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://www.reddit.com/r/Accounting/comments/ed5mnc/stories_of_toxic_coworkersteams/"
+              target="_blank"
+            >
+              Reddit, stories of toxic coworkers/teams
+            </a>
+          </li>
+        </ol>
+      </PlainBlogText>
+    </BlogEntry>
+  );
+}

--- a/packages/frontend/src/components/blog/BlogLinks.tsx
+++ b/packages/frontend/src/components/blog/BlogLinks.tsx
@@ -72,6 +72,15 @@ export const BLOG_LINKS: BlogLink[] = [
       "The positive effects of a monorepo on engineering team culture.",
     href: "/blog/engineering/monorepo-culture",
     title: "The monorepo culture"
+  },
+  {
+    author: "Kadhir",
+    category: "engineering",
+    date: "06/12/2025, 10:00 AM",
+    description:
+      "Some thoughts on the causes of toxic engineering teams and what to do about it.",
+    href: "/blog/engineering/toxic-teams",
+    title: "Toxic teams"
   }
 ];
 

--- a/packages/games/package.json
+++ b/packages/games/package.json
@@ -7,6 +7,7 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@reduxjs/toolkit": "^2.7.0",
     "clsx": "^2.1.1",
+    "konva": "^9.3.20",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "lucide-react": "^0.501.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4153,6 +4153,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     eslint: "npm:^9.25.0"
     jest: "npm:^29.7.0"
+    konva: "npm:^9.3.20"
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
     lucide-react: "npm:^0.501.0"
@@ -4195,6 +4196,7 @@ __metadata:
     eslint: "npm:^9.25.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
+    konva: "npm:^9.3.20"
     lodash-es: "npm:^4.17.21"
     lucide-react: "npm:^0.501.0"
     motion: "npm:^12.7.4"
@@ -10925,6 +10927,13 @@ __metadata:
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: 10c0/cd3a0b8878e7d6d3799e54340efe3591ca787d9f95f109f28129bdd2915e37807bf8918bb295ab86afb8c82196beec5a1adcaf29042ce3f2bd932b038fe3aa4b
+  languageName: node
+  linkType: hard
+
+"konva@npm:^9.3.20":
+  version: 9.3.20
+  resolution: "konva@npm:9.3.20"
+  checksum: 10c0/726d52e7105c747a080ba9bfe35bf07fa9dd40c4ae122f061d55723d907b6b7a09e8476cb5277ca0bcaf5504f4f79805ae2db0c29b72c9715b96ceae5c2a1d06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request introduces a new blog post on toxic engineering teams, integrates it into the frontend application, and updates dependencies across multiple packages. The most significant changes include adding the blog content, creating a new page for the blog post, and updating package dependencies.

### Blog Post Integration:
* [`blog-post.md`](diffhunk://#diff-593bf82b3dad599c9abd4726b4a3e4f5b727cefd504762831e0668201dd228beR1-R42): Added content for a blog post discussing toxic engineering teams, their causes, and potential solutions.
* [`packages/frontend/src/app/blog/engineering/toxic-teams/page.tsx`](diffhunk://#diff-71f4d1492f221b4bc20447a6268556d28593e050abc8a98f5ec36a4a7b19f3fdR1-R172): Created a new page for the blog post using the `BlogEntry`, `BlogText`, and `PlainBlogText` components, and included external references for further reading.
* [`packages/frontend/src/components/blog/BlogLinks.tsx`](diffhunk://#diff-2c178915a5eedecec4186fe3df5650d486e716d24ca72ab5d9b4323caf6ebb47R75-R83): Added metadata for the new blog post to the `BLOG_LINKS` array, enabling navigation to the post from the blog links component.

### Dependency Updates:
* [`packages/frontend/package.json`](diffhunk://#diff-8571ecd91584b00015b23695d3a6a164282636bb47bfbe46dca243bf9b4db773R22): Added `konva` dependency, version `^9.3.20`.
* [`packages/games/package.json`](diffhunk://#diff-6f7eee10b1a6559860a8f817a108b303a175792491ccb370ccd04f7e0e93cf9bR10): Added `konva` dependency, version `^9.3.20`.