### PR TITLE
Add custom drawing board to frontend

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,7 +19,6 @@
     "clsx": "^2.1.1",
     "copy-to-clipboard": "^3.3.3",
     "create-hash": "^1.2.0",
-    "konva": "^9.3.20",
     "lodash-es": "^4.17.21",
     "lucide-react": "^0.501.0",
     "motion": "^12.7.4",

--- a/packages/frontend/src/components/joinGame/JoinGame.tsx
+++ b/packages/frontend/src/components/joinGame/JoinGame.tsx
@@ -2,12 +2,12 @@ import { isServiceError } from "@/imports/api";
 import { Button, DisplayText, TextField } from "@/lib/radix";
 import { Flex } from "@/lib/radix/Flex";
 import { ClientServiceCallers } from "@/services/serviceCallers";
+import { EarthIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useContext, useState } from "react";
-import { PlayerContext } from "../player/PlayerContext";
-import { EarthIcon } from "lucide-react";
-import styles from "./JoinGame.module.scss";
 import { useMediaQuery } from "../../lib/hooks/useMediaQuery";
+import { PlayerContext } from "../player/PlayerContext";
+import styles from "./JoinGame.module.scss";
 
 export function JoinGame() {
   const { isMobile } = useMediaQuery();

--- a/packages/frontend/src/lib/resync-components/DrawingBoard.tsx
+++ b/packages/frontend/src/lib/resync-components/DrawingBoard.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { throttle } from "lodash-es";
+
+interface Point {
+  x: number;
+  y: number;
+}
+
+export const DrawingBoard = ({
+  onCavasChange
+}: {
+  onCavasChange: (dataUrl: string) => void;
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [tool, setTool] = useState<"marker" | "eraser">("marker");
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [startPoint, setStartPoint] = useState<Point | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    // Set canvas size to match its container
+    const resizeCanvas = () => {
+      const parent = canvas.parentElement;
+      if (parent) {
+        canvas.width = parent.clientWidth;
+        canvas.height = parent.clientHeight;
+      }
+    };
+
+    resizeCanvas();
+    window.addEventListener("resize", resizeCanvas);
+
+    return () => {
+      window.removeEventListener("resize", resizeCanvas);
+    };
+  }, []);
+
+  const onSaveCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dataURL = canvas.toDataURL("image/png");
+    onCavasChange(dataURL);
+  }, []);
+
+  // Create throttled version of onSaveCanvas using lodash-es
+  const throttledSaveCanvas = useRef(throttle(onSaveCanvas, 300)).current;
+
+  const clearCanvas = () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Clear the canvas
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    throttledSaveCanvas();
+  };
+
+  const getPointFromEvent = (
+    e:
+      | React.MouseEvent<HTMLCanvasElement>
+      | React.TouchEvent<HTMLCanvasElement>,
+    canvas: HTMLCanvasElement
+  ): Point => {
+    const rect = canvas.getBoundingClientRect();
+    const clientX = ("touches" in e ? e.touches[0]?.clientX : e.clientX) ?? 0;
+    const clientY = ("touches" in e ? e.touches[0]?.clientY : e.clientY) ?? 0;
+
+    return {
+      x: clientX - rect.left,
+      y: clientY - rect.top
+    };
+  };
+
+  const startDrawing = (
+    e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
+  ) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const point = getPointFromEvent(e, canvas);
+    setIsDrawing(true);
+    setStartPoint(point);
+  };
+
+  const draw = (
+    e: React.MouseEvent<HTMLCanvasElement> | React.TouchEvent<HTMLCanvasElement>
+  ) => {
+    if (!isDrawing || !startPoint) return;
+
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const currentPoint = getPointFromEvent(e, canvas);
+
+    // Draw line
+    ctx.beginPath();
+    ctx.moveTo(startPoint.x, startPoint.y);
+    ctx.lineTo(currentPoint.x, currentPoint.y);
+
+    if (tool === "eraser") {
+      ctx.globalCompositeOperation = "destination-out";
+      ctx.lineWidth = 20;
+    } else {
+      ctx.globalCompositeOperation = "source-over";
+      ctx.lineWidth = 2;
+    }
+
+    ctx.strokeStyle = "#000000";
+    ctx.lineCap = "round";
+    ctx.stroke();
+
+    setStartPoint(currentPoint);
+    throttledSaveCanvas();
+  };
+
+  const stopDrawing = () => {
+    setIsDrawing(false);
+    setStartPoint(null);
+  };
+
+  return (
+    <div>
+      <div style={{ marginBottom: "10px" }}>
+        <button
+          onClick={() => setTool("marker")}
+          style={{
+            backgroundColor: tool === "marker" ? "#e0e0e0" : "white",
+            border: "1px solid #ccc",
+            borderRadius: "4px",
+            cursor: "pointer",
+            marginRight: "5px",
+            padding: "5px 10px"
+          }}
+        >
+          Marker
+        </button>
+        <button
+          onClick={() => setTool("eraser")}
+          style={{
+            backgroundColor: tool === "eraser" ? "#e0e0e0" : "white",
+            border: "1px solid #ccc",
+            borderRadius: "4px",
+            cursor: "pointer",
+            marginRight: "5px",
+            padding: "5px 10px"
+          }}
+        >
+          Eraser
+        </button>
+        <button
+          onClick={clearCanvas}
+          style={{
+            backgroundColor: "white",
+            border: "1px solid #ccc",
+            borderRadius: "4px",
+            cursor: "pointer",
+            marginRight: "5px",
+            padding: "5px 10px"
+          }}
+        >
+          Clear
+        </button>
+      </div>
+      <canvas
+        onMouseDown={startDrawing}
+        onMouseLeave={stopDrawing}
+        onMouseMove={draw}
+        onMouseUp={stopDrawing}
+        onTouchEnd={stopDrawing}
+        onTouchMove={draw}
+        onTouchStart={startDrawing}
+        ref={canvasRef}
+        style={{
+          border: "1px solid #ccc",
+          borderRadius: "4px",
+          cursor: tool === "eraser" ? "cell" : "crosshair",
+          touchAction: "none"
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/games/package.json
+++ b/packages/games/package.json
@@ -7,7 +7,6 @@
     "@radix-ui/react-icons": "^1.3.2",
     "@reduxjs/toolkit": "^2.7.0",
     "clsx": "^2.1.1",
-    "konva": "^9.3.20",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",
     "lucide-react": "^0.501.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4153,7 +4153,6 @@ __metadata:
     clsx: "npm:^2.1.1"
     eslint: "npm:^9.25.0"
     jest: "npm:^29.7.0"
-    konva: "npm:^9.3.20"
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"
     lucide-react: "npm:^0.501.0"
@@ -4196,7 +4195,6 @@ __metadata:
     eslint: "npm:^9.25.0"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
-    konva: "npm:^9.3.20"
     lodash-es: "npm:^4.17.21"
     lucide-react: "npm:^0.501.0"
     motion: "npm:^12.7.4"
@@ -10927,13 +10925,6 @@ __metadata:
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
   checksum: 10c0/cd3a0b8878e7d6d3799e54340efe3591ca787d9f95f109f28129bdd2915e37807bf8918bb295ab86afb8c82196beec5a1adcaf29042ce3f2bd932b038fe3aa4b
-  languageName: node
-  linkType: hard
-
-"konva@npm:^9.3.20":
-  version: 9.3.20
-  resolution: "konva@npm:9.3.20"
-  checksum: 10c0/726d52e7105c747a080ba9bfe35bf07fa9dd40c4ae122f061d55723d907b6b7a09e8476cb5277ca0bcaf5504f4f79805ae2db0c29b72c9715b96ceae5c2a1d06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request includes changes to remove the `konva` library from dependencies, refactor imports in the `JoinGame` component, and add a new `DrawingBoard` component that provides a canvas for drawing. Below is a summary of the most important changes grouped by theme.

### Dependency Updates:
* Removed `konva` from dependencies in `packages/frontend/package.json` and `packages/games/package.json` as it is no longer required. [[1]](diffhunk://#diff-8571ecd91584b00015b23695d3a6a164282636bb47bfbe46dca243bf9b4db773L22) [[2]](diffhunk://#diff-6f7eee10b1a6559860a8f817a108b303a175792491ccb370ccd04f7e0e93cf9bL10)

### Code Refactoring:
* Refactored import statements in `packages/frontend/src/components/joinGame/JoinGame.tsx` to improve readability by reordering and removing redundant lines.

### New Feature:
* Added a `DrawingBoard` component in `packages/frontend/src/lib/resync-components/DrawingBoard.tsx`. This component provides a canvas for drawing with tools like a marker and eraser, supports resizing, and includes functionality to clear the canvas and save its state using throttled updates.