### PR TITLE
Wire the drawing board into fishbowl

### DIFF
--- a/packages/games/lib/resync-components/index.ts
+++ b/packages/games/lib/resync-components/index.ts
@@ -1,0 +1,1 @@
+export * from "@resync-games/frontend/lib/resync-components/DrawingBoard";

--- a/packages/games/src/backend/fishbowl/fishbowl.ts
+++ b/packages/games/src/backend/fishbowl/fishbowl.ts
@@ -65,11 +65,29 @@ export interface FishbowlSingleGuess {
   timestamp: string;
 }
 
+export interface FishbowlCorrectSingleGuess extends FishbowlSingleGuess {
+  /**
+   * The current active player's drawing for the active word.
+   */
+  currentActiveDrawing: string | undefined;
+}
+
+export interface FishbowlActiveDrawing extends WithTimestamp {
+  /**
+   * The drawing that the player is currently giving clues for.
+   */
+  drawing: string | undefined;
+}
+
 export interface FishbowlRound extends WithTimestamp {
   /**
    * All correct guesses for this round. Here for player reference.
    */
-  correctGuesses: FishbowlSingleGuess[];
+  correctGuesses: FishbowlCorrectSingleGuess[];
+  /**
+   * The current active player's drawing for the active word.
+   */
+  currentActiveDrawing: FishbowlActiveDrawing | undefined;
   /**
    * The player who is currently giving clues.
    */

--- a/packages/games/src/frontend/fishbowl/globalScreen/components/DisplayDrawing.module.scss
+++ b/packages/games/src/frontend/fishbowl/globalScreen/components/DisplayDrawing.module.scss
@@ -1,0 +1,10 @@
+@use "@/styles/variables.scss" as vars;
+
+.drawing {
+    z-index: 1;
+    position: absolute;
+    bottom: 10px;
+    right: 30vh;
+    border: 2px solid vars.$black;
+    background: vars.$white;
+}

--- a/packages/games/src/frontend/fishbowl/globalScreen/components/DisplayDrawing.tsx
+++ b/packages/games/src/frontend/fishbowl/globalScreen/components/DisplayDrawing.tsx
@@ -1,0 +1,37 @@
+import { Flex } from "@/lib/radix";
+import { useFishbowlSelector } from "../../store/fishbowlRedux";
+import styles from "./DisplayDrawing.module.scss";
+
+export const DisplayDrawing = () => {
+  const activeDrawing = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round?.currentActiveDrawing
+  );
+  const timerState = useFishbowlSelector(
+    (s) => s.gameStateSlice.gameState?.round?.currentActivePlayer.timer.state
+  );
+
+  if (
+    activeDrawing === undefined ||
+    activeDrawing.drawing === undefined ||
+    timerState !== "running"
+  ) {
+    return;
+  }
+
+  const width = window.innerWidth * 0.6;
+  const height = window.innerHeight * 0.6;
+
+  const dimension = Math.min(width, height);
+
+  return (
+    <Flex className={styles.drawing}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        alt="Drawing"
+        height={dimension}
+        src={activeDrawing.drawing}
+        width={dimension}
+      />
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/fishbowl/globalScreen/components/RoundInProgress.tsx
+++ b/packages/games/src/frontend/fishbowl/globalScreen/components/RoundInProgress.tsx
@@ -6,6 +6,7 @@ import { useAdvancePlayer } from "../hooks/useAdvancePlayer";
 import { useNextWord } from "../hooks/useNextWord";
 import { NextRoundIdentifier } from "./NextRoundIdentifier";
 import { ViewWords } from "./ViewWords";
+import { DisplayDrawing } from "./DisplayDrawing";
 
 export const RoundInProgress = () => {
   useAdvancePlayer();
@@ -26,6 +27,7 @@ export const RoundInProgress = () => {
       {helpers()}
       <GlobalActivePlayer />
       <CurrentGuesses />
+      <DisplayDrawing />
     </Flex>
   );
 };

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/activePlayer/ActivePlayer.tsx
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/activePlayer/ActivePlayer.tsx
@@ -3,14 +3,18 @@ import { useFishbowlSelector } from "../../../store/fishbowlRedux";
 import { selectActiveRound } from "../../selectors/playerSelectors";
 import { FishbowlTimer } from "../../timer/FishbowlTimer";
 import { ActiveWord } from "./ActiveWord";
+import { DrawingMode } from "./DrawingMode";
 import { SomeoneGotIt } from "./SomeoneGotIt";
 import { TimerControl } from "./TimerControl";
+import { useState } from "react";
 
 export const ActivePlayer = () => {
   const timer = useFishbowlSelector(
     (s) => s.gameStateSlice.gameState?.round?.currentActivePlayer.timer
   );
   const activeRound = useFishbowlSelector(selectActiveRound);
+
+  const [drawingMode, setDrawingMode] = useState(false);
 
   if (timer === undefined || activeRound === undefined) {
     return;
@@ -67,6 +71,12 @@ export const ActivePlayer = () => {
         <Flex align="center" gap="2">
           <SomeoneGotIt timer={timer} />
           <TimerControl />
+        </Flex>
+        <Flex flex={drawingMode ? "1" : "0"}>
+          <DrawingMode
+            drawingMode={drawingMode}
+            setDrawingMode={setDrawingMode}
+          />
         </Flex>
       </Flex>
     </Flex>

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/activePlayer/DrawingMode.tsx
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/activePlayer/DrawingMode.tsx
@@ -1,0 +1,65 @@
+import { PencilLineIcon } from "lucide-react";
+import { DrawingBoard } from "../../../../../../lib/resync-components";
+import {
+  updateFishbowlGameState,
+  useFishbowlDispatch,
+  useFishbowlSelector
+} from "../../../store/fishbowlRedux";
+import {
+  selectActiveRound,
+  selectFishbowlPlayer
+} from "../../selectors/playerSelectors";
+import { Button, DisplayText, Flex } from "@/lib/radix";
+
+export const DrawingMode = ({
+  drawingMode,
+  setDrawingMode
+}: {
+  drawingMode: boolean;
+  setDrawingMode: (drawingMode: boolean) => void;
+}) => {
+  const dispatch = useFishbowlDispatch();
+
+  const activePlayer = useFishbowlSelector(selectFishbowlPlayer);
+  const activeRound = useFishbowlSelector(selectActiveRound);
+
+  const onCavasChange = (dataUrl: string) => {
+    if (activePlayer === undefined) {
+      return;
+    }
+
+    dispatch(
+      updateFishbowlGameState(
+        {
+          round: {
+            currentActiveDrawing: {
+              drawing: dataUrl,
+              lastUpdatedAt: new Date().toISOString()
+            }
+          }
+        },
+        activePlayer
+      )
+    );
+  };
+
+  if (!drawingMode) {
+    return (
+      <Flex flex="1" justify="end">
+        <Flex>
+          <Button onClick={() => setDrawingMode(true)} variant="outline">
+            <DisplayText>Drawing</DisplayText>
+            <PencilLineIcon />
+          </Button>
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return (
+    <DrawingBoard
+      initialDataUrl={activeRound?.currentActiveDrawing?.drawing}
+      onCavasChange={onCavasChange}
+    />
+  );
+};

--- a/packages/games/src/frontend/fishbowl/stateFunctions/advanceToNextPlayer.ts
+++ b/packages/games/src/frontend/fishbowl/stateFunctions/advanceToNextPlayer.ts
@@ -55,6 +55,7 @@ export function advanceToNextPlayer(
     timer: fishbowlActiveTracker
   };
   newFishbowlRound.currentActivePlayer = nextActivePlayer;
+  newFishbowlRound.currentActiveDrawing = undefined;
 
   return newFishbowlRound;
 }

--- a/packages/games/src/frontend/fishbowl/stateFunctions/advanceWord.ts
+++ b/packages/games/src/frontend/fishbowl/stateFunctions/advanceWord.ts
@@ -21,6 +21,7 @@ export function advanceWord(
 
   updatedRound.correctGuesses.push({
     ...activeRound.currentActiveWord,
+    currentActiveDrawing: activeRound.currentActiveDrawing?.drawing,
     currentActivePlayer: activeRound.currentActivePlayer.player,
     currentActiveWord: activeRound.currentActiveWord,
     guess: activeRound.currentActiveWord.word,
@@ -28,6 +29,8 @@ export function advanceWord(
     roundNumber: activeRound.roundNumber,
     timestamp: new Date().toISOString()
   });
+
+  updatedRound.currentActiveDrawing = undefined;
 
   const newWord = sample(updatedRound.remainingWords);
   if (newWord === undefined) {

--- a/packages/games/src/frontend/fishbowl/stateFunctions/newRound.ts
+++ b/packages/games/src/frontend/fishbowl/stateFunctions/newRound.ts
@@ -70,6 +70,7 @@ export function newRound(
 
   const nextFishbowlRound: FishbowlRound = {
     correctGuesses: [],
+    currentActiveDrawing: undefined,
     currentActivePlayer: getActivePlayer(
       gameState,
       allPlayers,

--- a/packages/games/src/shared/gamesRegistry.ts
+++ b/packages/games/src/shared/gamesRegistry.ts
@@ -25,7 +25,9 @@ export const GAME_REGISTRY: GameRegistry = {
   fishbowl: {
     description:
       "A game where you have to guess words based on the clues given by your teammates. The kinds of clues given by your teammates changes every round.",
-    gameTags: {},
+    gameTags: {
+      completed: true
+    },
     name: "Fishbowl",
     version: "1.0.0"
   },


### PR DESCRIPTION
This pull request introduces enhancements to the `DrawingBoard` component and integrates drawing functionality into the `Fishbowl` game. The changes include updates to the `DrawingBoard` component to support initial data loading and throttled canvas saving, new interfaces and state updates for managing drawings in `Fishbowl`, and frontend components for displaying and interacting with drawings during gameplay.

### DrawingBoard Enhancements:
* [`packages/frontend/src/lib/resync-components/DrawingBoard.tsx`](diffhunk://#diff-ab0f651567b76ad4bfc901ead8ef052d810784180b36aeffe7b8dfed3083a972L10-R13): Added support for loading an initial image (`initialDataUrl`) onto the canvas and implemented a throttled `onSaveCanvas` function using `lodash-es`. These changes improve the component's usability and performance. [[1]](diffhunk://#diff-ab0f651567b76ad4bfc901ead8ef052d810784180b36aeffe7b8dfed3083a972L10-R13) [[2]](diffhunk://#diff-ab0f651567b76ad4bfc901ead8ef052d810784180b36aeffe7b8dfed3083a972R22-R49) [[3]](diffhunk://#diff-ab0f651567b76ad4bfc901ead8ef052d810784180b36aeffe7b8dfed3083a972R61-R65) [[4]](diffhunk://#diff-ab0f651567b76ad4bfc901ead8ef052d810784180b36aeffe7b8dfed3083a972L39-R75)

### Fishbowl Game Integration:
* [`packages/games/src/backend/fishbowl/fishbowl.ts`](diffhunk://#diff-62a5e588fb461601e0f396ff183c9da94013e364673b703468396e250ea3535eR68-R90): Introduced new interfaces (`FishbowlCorrectSingleGuess` and `FishbowlActiveDrawing`) to manage drawings associated with guesses and active rounds. Updated the `FishbowlRound` interface to include `currentActiveDrawing`.
* [`packages/games/src/frontend/fishbowl/globalScreen/components/DisplayDrawing.tsx`](diffhunk://#diff-f8757c207fc72bdbb4c1d049a49413e08611d1670f57cc530490302e28a3b687R1-R37): Created a new `DisplayDrawing` component to display the active player's drawing during gameplay.
* [`packages/games/src/frontend/fishbowl/playerComponents/components/activePlayer/DrawingMode.tsx`](diffhunk://#diff-5d850a555630f13309cff16dd27dc3fca6fed6f649eb93213ecb638812e4fcfaR1-R65): Added the `DrawingMode` component, allowing players to create and update drawings during rounds. Integrated the `DrawingBoard` component for drawing functionality.
* `packages/games/src/frontend/fishbowl/stateFunctions/advanceToNextPlayer.ts`, `advanceWord.ts`, `newRound.ts`: Ensured that `currentActiveDrawing` is reset appropriately when advancing to the next player, word, or round. [[1]](diffhunk://#diff-09c6984a0a8ac8773b9fad7b8ff70e377bec046190044b68550b93ef985337b5R58) [[2]](diffhunk://#diff-a75a41036dd29f6699cc86d65adb01958658565e1238973f9cd514b6a4c50131R24) [[3]](diffhunk://#diff-a75a41036dd29f6699cc86d65adb01958658565e1238973f9cd514b6a4c50131R33-R34) [[4]](diffhunk://#diff-f252a1d4a4923b1320d989220c68b4d7999afa22e384697f7f7457b1e529a5beR73)

### Styling and Component Integration:
* [`packages/games/src/frontend/fishbowl/globalScreen/components/DisplayDrawing.module.scss`](diffhunk://#diff-9ada16469f8c4a049963bdd227839e8de6ebc2ccbb1f32d538b79ce4d7659f9dR1-R10): Added styles for the `DisplayDrawing` component to ensure proper positioning and appearance.
* [`packages/games/src/frontend/fishbowl/globalScreen/components/RoundInProgress.tsx`](diffhunk://#diff-bbcd403c3ffe1110047c59be4f08c6a5388607a777eb89981e17972745345b3bR9): Integrated the `DisplayDrawing` component into the `RoundInProgress` screen to show drawings during active rounds. [[1]](diffhunk://#diff-bbcd403c3ffe1110047c59be4f08c6a5388607a777eb89981e17972745345b3bR9) [[2]](diffhunk://#diff-bbcd403c3ffe1110047c59be4f08c6a5388607a777eb89981e17972745345b3bR30)

### Miscellaneous:
* [`packages/games/src/shared/gamesRegistry.ts`](diffhunk://#diff-736a57a094eede1125781d447cba26175e0c4546b306976a53030e44fd345b6eL28-R30): Updated the `Fishbowl` game registry to mark the game as completed.
* [`packages/games/lib/resync-components/index.ts`](diffhunk://#diff-965549b3b8178c182368ff268b607504b7347afb5b2bd2cb37df97f24d40af9aR1): Exported the `DrawingBoard` component for reuse across modules.