### PR TITLE
Enforce twitter button loading

### DIFF
--- a/packages/frontend/src/components/blog/BlogEntry.tsx
+++ b/packages/frontend/src/components/blog/BlogEntry.tsx
@@ -6,10 +6,19 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Script from "next/script";
 import styles from "./BlogEntry.module.scss";
+import { useEffect } from "react";
+
+interface TwitterWindow {
+  twttr: { widgets: { load: () => void } };
+}
 
 export const BlogEntry = ({ children }: { children: React.ReactNode }) => {
   const pathname = usePathname();
   const currentCategory = pathname.split("/")[2];
+
+  useEffect(() => {
+    (window as unknown as TwitterWindow).twttr?.widgets.load();
+  }, []);
 
   return (
     <Flex className={styles.content} direction="column">
@@ -27,6 +36,9 @@ export const BlogEntry = ({ children }: { children: React.ReactNode }) => {
             Follow @kadhir_velm
           </a>
           <Script
+            onLoad={() => {
+              (window as unknown as TwitterWindow).twttr?.widgets.load();
+            }}
             src="https://platform.twitter.com/widgets.js"
             strategy="afterInteractive"
           />


### PR DESCRIPTION
This pull request updates the `BlogEntry` component in the frontend to ensure Twitter widgets are properly loaded when the page renders or the Twitter script is loaded. The most important changes include adding a `useEffect` hook to trigger the widget load on component mount and adding an `onLoad` handler to the Twitter script.

Enhancements for loading Twitter widgets:

* [`packages/frontend/src/components/blog/BlogEntry.tsx`](diffhunk://#diff-e55c26cfe7b523407de46890d2acd331d6049244ce0a84df5a4e572693d2cac7R9-R22): Added a `useEffect` hook that calls `twttr.widgets.load()` to ensure Twitter widgets are initialized when the `BlogEntry` component is mounted.
* [`packages/frontend/src/components/blog/BlogEntry.tsx`](diffhunk://#diff-e55c26cfe7b523407de46890d2acd331d6049244ce0a84df5a4e572693d2cac7R39-R41): Added an `onLoad` handler to the Twitter `Script` component to reinitialize Twitter widgets when the script is loaded.