### PR TITLE
Flush out backend to initializing a game from state

### DIFF
--- a/packages/api/services/snapshotState/snapshotStateService.ts
+++ b/packages/api/services/snapshotState/snapshotStateService.ts
@@ -1,5 +1,6 @@
 import { Service, ServiceDefinition } from "../../genericTypes/service";
-import { GameType } from "../gameState";
+import { GameId, GameType } from "../gameState";
+import { Player } from "../user";
 
 export interface SnapshotState {
   description: string;
@@ -7,13 +8,22 @@ export interface SnapshotState {
   gameType: GameType;
   localStateSlice: object;
   playerSlice: object;
+  snapshotId: SnapshotId;
   timestamp: string;
 }
 
 export type SnapshotStateDisplay = Pick<
   SnapshotState,
-  "description" | "gameType" | "timestamp"
+  "description" | "gameType" | "snapshotId" | "timestamp"
 >;
+
+export interface InitiateGameFromSnapshotResponse {
+  gameId: GameId;
+  gameStateSlice: object;
+  localStateSlice: object;
+  playerSlice: object;
+  players: Player[];
+}
 
 export type SnapshotId = string & { __brand: "snapshot-id" };
 
@@ -24,8 +34,12 @@ export interface SnapshotStateApi extends Service {
       snapshotStates: SnapshotStateDisplay[];
     };
   };
+  initiateGameFromSnapshot: {
+    payload: SnapshotStateDisplay;
+    response: InitiateGameFromSnapshotResponse;
+  };
   snapshotState: {
-    payload: Omit<SnapshotState, "timestamp">;
+    payload: Omit<SnapshotState, "snapshotId" | "timestamp">;
     response: { snapshotId: SnapshotId };
   };
 }
@@ -35,6 +49,7 @@ export const SnapshotStateServiceDefinition: ServiceDefinition<SnapshotStateApi>
     controller: "snapshot-state",
     endpoints: {
       getSnapshotStates: "get-snapshot-states",
+      initiateGameFromSnapshot: "initiate-game-from-snapshot",
       snapshotState: "snapshot-state"
     }
   };

--- a/packages/backend/src/database/resyncGamesPrismaConverter.service.ts
+++ b/packages/backend/src/database/resyncGamesPrismaConverter.service.ts
@@ -6,7 +6,8 @@ import {
   PlayerId,
   GameStateAndInfo,
   SnapshotState,
-  SnapshotStateDisplay
+  SnapshotStateDisplay,
+  SnapshotId
 } from "@/imports/api";
 import {
   CurrentGameState,
@@ -62,6 +63,7 @@ export class ResyncGamesConverterService {
       gameType: snapshotState.gameType as GameType,
       localStateSlice: snapshotState.localSlice as object,
       playerSlice: snapshotState.playerSlice as object,
+      snapshotId: snapshotState.snapshotId as SnapshotId,
       timestamp: snapshotState.timestamp.toISOString()
     };
   };
@@ -72,6 +74,7 @@ export class ResyncGamesConverterService {
     return {
       description: snapshotState.description ?? "",
       gameType: snapshotState.gameType as GameType,
+      snapshotId: snapshotState.snapshotId as SnapshotId,
       timestamp: snapshotState.timestamp?.toISOString() ?? ""
     };
   };

--- a/packages/backend/src/snapshotState/snapshotState.controller.ts
+++ b/packages/backend/src/snapshotState/snapshotState.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller } from "@nestjs/common";
 import {
   SnapshotState,
   SnapshotStateApi,
+  SnapshotStateDisplay,
   SnapshotStateServiceDefinition
 } from "@/imports/api";
 import {
@@ -24,5 +25,12 @@ export class SnapshotStateController
   @getDecorator(SnapshotStateServiceDefinition.endpoints.getSnapshotStates)
   public async getSnapshotStates(@Body() _request: Record<string, never>) {
     return this.snapshotStateService.getSnapshotStates();
+  }
+
+  @getDecorator(
+    SnapshotStateServiceDefinition.endpoints.initiateGameFromSnapshot
+  )
+  public async initiateGameFromSnapshot(@Body() request: SnapshotStateDisplay) {
+    return this.snapshotStateService.initiateGameFromSnapshot(request);
   }
 }

--- a/packages/backend/src/snapshotState/snapshotState.module.ts
+++ b/packages/backend/src/snapshotState/snapshotState.module.ts
@@ -1,7 +1,7 @@
 import { Module } from "@nestjs/common";
+import { ResyncGamesPrismaModule } from "../database/resyncGamesPrisma.module";
 import { SnapshotStateController } from "./snapshotState.controller";
 import { SnapshotStateService } from "./snapshotState.service";
-import { ResyncGamesPrismaModule } from "../database/resyncGamesPrisma.module";
 
 @Module({
   controllers: [SnapshotStateController],

--- a/packages/frontend/src/components/createGame/CreateGame.module.scss
+++ b/packages/frontend/src/components/createGame/CreateGame.module.scss
@@ -22,3 +22,10 @@
     z-index: 1;
 }
 
+.snapshot {
+    cursor: pointer;
+
+    &:hover {
+        opacity: 0.6;
+    }
+}

--- a/packages/frontend/src/components/createGame/CreateGame.tsx
+++ b/packages/frontend/src/components/createGame/CreateGame.tsx
@@ -13,6 +13,8 @@ import { PlayerContext } from "../player/PlayerContext";
 import SelectGame, { SelectedGame } from "./components/SelectGame";
 import styles from "./CreateGame.module.scss";
 import { getDefaultConfiguration } from "./utils/getDefaultConfiguration";
+import { SettingsIcon } from "lucide-react";
+import { OpenSnapshotState } from "./components/OpenSnapshotState";
 
 export default function CreateGame() {
   const player = useContext(PlayerContext);
@@ -20,6 +22,7 @@ export default function CreateGame() {
 
   const [selectedGame, onSelectGame] = useState<SelectedGame | undefined>();
   const [isLoading, setIsLoading] = useState(false);
+  const [openSnapshot, setOpenSnapshot] = useState(true);
 
   const onCreateGame = async () => {
     if (selectedGame === undefined) {
@@ -57,9 +60,26 @@ export default function CreateGame() {
       </Flex>
       <Flex className={styles.formBox} direction="column" gap="3">
         <Flex direction="column" gap="2">
-          <SelectGame onSelectGame={onSelectGame} selectedGame={selectedGame} />
+          {openSnapshot ? (
+            <OpenSnapshotState />
+          ) : (
+            <SelectGame
+              onSelectGame={onSelectGame}
+              selectedGame={selectedGame}
+            />
+          )}
         </Flex>
-        <Flex justify="end" mt="2">
+        <Flex align="center" justify="end" mt="2">
+          {process.env.NEXT_PUBLIC_DEVELOPMENT_MODE === "true" && (
+            <Flex flex="1" mr="2">
+              <SettingsIcon
+                className={styles.snapshot}
+                color={openSnapshot ? "blue" : undefined}
+                onClick={() => setOpenSnapshot(!openSnapshot)}
+                size={16}
+              />
+            </Flex>
+          )}
           <Flex>
             <Button
               disabled={selectedGame === undefined}

--- a/packages/frontend/src/components/createGame/components/OpenSnapshotState.module.scss
+++ b/packages/frontend/src/components/createGame/components/OpenSnapshotState.module.scss
@@ -1,0 +1,11 @@
+@use "@/styles/variables.scss" as vars;
+
+.snapshot {
+    border: 1px solid vars.$border-color;
+    border-radius: 3px;
+    cursor: pointer;
+
+    &:hover {
+        background: vars.$hover;
+    }
+}

--- a/packages/frontend/src/components/createGame/components/OpenSnapshotState.tsx
+++ b/packages/frontend/src/components/createGame/components/OpenSnapshotState.tsx
@@ -1,0 +1,88 @@
+import { DisplayText, Flex, Spinner } from "../../../lib/radix";
+import { ClientServiceCallers } from "../../../services/serviceCallers";
+import { useEffect, useState } from "react";
+import { isServiceError, SnapshotStateDisplay } from "@/imports/api";
+import styles from "./OpenSnapshotState.module.scss";
+import { useRouter } from "next/navigation";
+
+export const OpenSnapshotState = () => {
+  const router = useRouter();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [availableSnapshots, setAvailableSnapshots] = useState<
+    SnapshotStateDisplay[]
+  >([]);
+
+  const getAvailableSnapshots = async () => {
+    setIsLoading(true);
+    const snapshots =
+      await ClientServiceCallers.snapshotState.getSnapshotStates({});
+
+    if (isServiceError(snapshots)) {
+      console.error(snapshots);
+      return;
+    }
+
+    setAvailableSnapshots(snapshots.snapshotStates);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    getAvailableSnapshots();
+  }, []);
+
+  if (isLoading) {
+    return (
+      <Flex align="center" flex="1" justify="center">
+        <Spinner />
+      </Flex>
+    );
+  }
+
+  const onInitiateGameFromSnapshot = async (snapshot: SnapshotStateDisplay) => {
+    setIsLoading(true);
+    const response =
+      await ClientServiceCallers.snapshotState.initiateGameFromSnapshot({
+        ...snapshot
+      });
+    setIsLoading(false);
+
+    if (isServiceError(response)) {
+      console.error(response);
+      return;
+    }
+
+    router.push(`/${snapshot.gameType}/${response.gameId}`);
+  };
+
+  return (
+    <Flex direction="column" flex="1" gap="2">
+      <Flex align="center">
+        <DisplayText color="gray" size="2">
+          {availableSnapshots.length} snapshot
+          {availableSnapshots.length === 1 ? "" : "s"} available
+        </DisplayText>
+      </Flex>
+      {availableSnapshots.map((snapshot) => (
+        <Flex
+          className={styles.snapshot}
+          direction="column"
+          gap="3"
+          key={snapshot.timestamp}
+          onClick={() => onInitiateGameFromSnapshot(snapshot)}
+          p="2"
+        >
+          <Flex align="center" justify="between">
+            <DisplayText>{snapshot.gameType}</DisplayText>
+            <DisplayText>
+              {new Date(snapshot.timestamp).toLocaleString()}
+            </DisplayText>
+          </Flex>
+          <DisplayText color="gray" size="2">
+            {snapshot.description}
+          </DisplayText>
+        </Flex>
+      ))}
+    </Flex>
+  );
+};


### PR DESCRIPTION
This pull request introduces a new feature to initiate a game from a snapshot, along with supporting backend and frontend changes. The most important updates include extending the snapshot state API, implementing the backend logic for game initiation, and adding a UI component to handle snapshots in the game creation flow.

### Backend Changes

* **Snapshot State API Enhancements**:
  - Added a new `initiateGameFromSnapshot` endpoint to the `SnapshotStateApi` interface, with corresponding payload and response types (`InitiateGameFromSnapshotResponse`). (`[[1]](diffhunk://#diff-f3a13cc38b71f93505f3b495ace5a5982f63147b4ff98ca60dfbbec6d6a15c8eL2-R27)`, `[[2]](diffhunk://#diff-f3a13cc38b71f93505f3b495ace5a5982f63147b4ff98ca60dfbbec6d6a15c8eR37-R42)`, `[[3]](diffhunk://#diff-f3a13cc38b71f93505f3b495ace5a5982f63147b4ff98ca60dfbbec6d6a15c8eR52)`)
  - Updated the `SnapshotState` and `SnapshotStateDisplay` interfaces to include the `snapshotId` field. (`[packages/api/services/snapshotState/snapshotStateService.tsL2-R27](diffhunk://#diff-f3a13cc38b71f93505f3b495ace5a5982f63147b4ff98ca60dfbbec6d6a15c8eL2-R27)`)

* **Game Initiation Logic**:
  - Implemented `initiateGameFromSnapshot` in `SnapshotStateService`, which retrieves a snapshot, creates new players, and initializes a new game using the snapshot data. (`[packages/backend/src/snapshotState/snapshotState.service.tsR53-R116](diffhunk://#diff-6ada1dcc7decbcfe7442e2c90faa3ff11d043967fc6a5f6a51873859c96c9f35R53-R116)`)
  - Added ordering by timestamp in the `getSnapshotStates` method to ensure snapshots are retrieved in descending order of creation. (`[packages/backend/src/snapshotState/snapshotState.service.tsR36-R42](diffhunk://#diff-6ada1dcc7decbcfe7442e2c90faa3ff11d043967fc6a5f6a51873859c96c9f35R36-R42)`)

### Frontend Changes

* **Snapshot State UI**:
  - Introduced a new `OpenSnapshotState` component to display available snapshots and allow users to initiate a game from a selected snapshot. (`[packages/frontend/src/components/createGame/components/OpenSnapshotState.tsxR1-R88](diffhunk://#diff-f80a17d987547fda90cf4d7bbeb1d0431f826ff80c59111c1947bc72a93526b3R1-R88)`)
  - Updated the `CreateGame` component to toggle between selecting a game and opening a snapshot, with a development mode toggle for the snapshot feature. (`[[1]](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773R16-R25)`, `[[2]](diffhunk://#diff-70fcdb806e52a926c2ad1e125a4a04d976032de0a51846a7915e155c3460c773L60-R82)`)

* **Styling Updates**:
  - Added CSS styling for the snapshot state UI in `OpenSnapshotState.module.scss` and updated styles in `CreateGame.module.scss`. (`[[1]](diffhunk://#diff-09d04e619ed118ffec63c432e7a5fa24be83936b44fa37b972557eb3ed08a1ebR25-R31)`, `[[2]](diffhunk://#diff-6df4dca0eef7384e017b4f2e8b9e096a334af3fad744b7996922dde2c422934dR1-R11)`)

These changes collectively enable users to create games directly from snapshots, improving the flexibility and usability of the game creation process.