### PR TITLE
Add delete snapshot button

### DIFF
--- a/packages/api/services/snapshotState/snapshotStateService.ts
+++ b/packages/api/services/snapshotState/snapshotStateService.ts
@@ -42,9 +42,17 @@ export interface ResetGameToSnapshotResponse {
   playerSlice: object;
 }
 
+export interface DeleteSnapshotStateRequest {
+  snapshotId: SnapshotId;
+}
+
 export type SnapshotId = string & { __brand: "snapshot-id" };
 
 export interface SnapshotStateApi extends Service {
+  deleteSnapshotState: {
+    payload: DeleteSnapshotStateRequest;
+    response: Record<string, never>;
+  };
   getSnapshotStates: {
     payload: Record<string, never>;
     response: {
@@ -73,6 +81,7 @@ export const SnapshotStateServiceDefinition: ServiceDefinition<SnapshotStateApi>
   {
     controller: "snapshot-state",
     endpoints: {
+      deleteSnapshotState: "delete-snapshot-state",
       getSnapshotStates: "get-snapshot-states",
       initiateGameFromSnapshot: "initiate-game-from-snapshot",
       resetGameToSnapshot: "reset-game-to-snapshot",

--- a/packages/backend/src/snapshotState/snapshotState.controller.ts
+++ b/packages/backend/src/snapshotState/snapshotState.controller.ts
@@ -1,4 +1,5 @@
 import {
+  DeleteSnapshotStateRequest,
   ResetGameToSnapshotRequest,
   SnapshotState,
   SnapshotStateApi,
@@ -46,5 +47,14 @@ export class SnapshotStateController
   @getDecorator(SnapshotStateServiceDefinition.endpoints.updateSnapshotState)
   public async updateSnapshotState(@Body() request: UpdateSnapshotStatRequest) {
     return this.snapshotStateService.updateSnapshotState(request);
+  }
+
+  @getDecorator(SnapshotStateServiceDefinition.endpoints.deleteSnapshotState)
+  public async deleteSnapshotState(
+    @Body() request: DeleteSnapshotStateRequest
+  ) {
+    await this.snapshotStateService.deleteSnapshotState(request.snapshotId);
+
+    return {};
   }
 }

--- a/packages/backend/src/snapshotState/snapshotState.service.ts
+++ b/packages/backend/src/snapshotState/snapshotState.service.ts
@@ -220,4 +220,10 @@ export class SnapshotStateService {
 
     return { snapshotId: updateSnapshotStateRequest.snapshotId as SnapshotId };
   };
+
+  public deleteSnapshotState = async (snapshotId: SnapshotId) => {
+    await this.prismaService.client.snapshotState.delete({
+      where: { snapshotId }
+    });
+  };
 }

--- a/packages/frontend/src/components/createGame/components/OpenSnapshotState.tsx
+++ b/packages/frontend/src/components/createGame/components/OpenSnapshotState.tsx
@@ -1,9 +1,14 @@
-import { DisplayText, Flex, Spinner } from "../../../lib/radix";
-import { ClientServiceCallers } from "../../../services/serviceCallers";
-import { useEffect, useState } from "react";
-import { isServiceError, SnapshotStateDisplay } from "@/imports/api";
-import styles from "./OpenSnapshotState.module.scss";
+import {
+  isServiceError,
+  SnapshotId,
+  SnapshotStateDisplay
+} from "@/imports/api";
+import { TrashIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { DisplayText, Flex, IconButton, Spinner } from "../../../lib/radix";
+import { ClientServiceCallers } from "../../../services/serviceCallers";
+import styles from "./OpenSnapshotState.module.scss";
 
 export const OpenSnapshotState = () => {
   const router = useRouter();
@@ -55,6 +60,24 @@ export const OpenSnapshotState = () => {
     router.push(`/${snapshot.gameType}/${response.gameId}`);
   };
 
+  const onDeleteSnapshot = async (snapshotId: SnapshotId) => {
+    const response =
+      await ClientServiceCallers.snapshotState.deleteSnapshotState({
+        snapshotId
+      });
+
+    if (isServiceError(response)) {
+      console.error(response);
+      return;
+    }
+
+    setAvailableSnapshots(
+      availableSnapshots.filter(
+        (snapshot) => snapshot.snapshotId !== snapshotId
+      )
+    );
+  };
+
   return (
     <Flex direction="column" flex="1" gap="2">
       <Flex align="center">
@@ -64,23 +87,30 @@ export const OpenSnapshotState = () => {
         </DisplayText>
       </Flex>
       {availableSnapshots.map((snapshot) => (
-        <Flex
-          className={styles.snapshot}
-          direction="column"
-          gap="3"
-          key={snapshot.timestamp}
-          onClick={() => onInitiateGameFromSnapshot(snapshot)}
-          p="2"
-        >
-          <Flex align="center" justify="between">
+        <Flex align="center" gap="2" key={snapshot.timestamp}>
+          <Flex
+            className={styles.snapshot}
+            direction="column"
+            flex="1"
+            gap="3"
+            onClick={() => onInitiateGameFromSnapshot(snapshot)}
+            p="4"
+          >
             <DisplayText>{snapshot.gameType}</DisplayText>
-            <DisplayText>
+            <DisplayText color="gray" size="2">
               {new Date(snapshot.timestamp).toLocaleString()}
             </DisplayText>
+            <DisplayText color="gray" size="2">
+              {snapshot.description}
+            </DisplayText>
           </Flex>
-          <DisplayText color="gray" size="2">
-            {snapshot.description}
-          </DisplayText>
+          <IconButton
+            color="red"
+            onClick={() => onDeleteSnapshot(snapshot.snapshotId)}
+            variant="outline"
+          >
+            <TrashIcon size={16} />
+          </IconButton>
         </Flex>
       ))}
     </Flex>

--- a/packages/frontend/src/lib/radix/IconButton.module.scss
+++ b/packages/frontend/src/lib/radix/IconButton.module.scss
@@ -1,0 +1,5 @@
+@use "@/styles/variables.scss" as vars;
+
+.iconButton {
+    cursor: pointer;
+}

--- a/packages/frontend/src/lib/radix/IconButton.tsx
+++ b/packages/frontend/src/lib/radix/IconButton.tsx
@@ -1,0 +1,22 @@
+import {
+  IconButton as RadixComponent,
+  IconButtonProps as RadixComponentProps
+} from "@radix-ui/themes";
+import clsx from "clsx";
+import styles from "./IconButton.module.scss";
+
+export interface IconButtonProps extends RadixComponentProps {
+  children: React.ReactNode;
+}
+
+export const IconButton = ({
+  className,
+  children,
+  ...props
+}: IconButtonProps) => {
+  return (
+    <RadixComponent {...props} className={clsx(className, styles.iconButton)}>
+      {children}
+    </RadixComponent>
+  );
+};

--- a/packages/frontend/src/lib/radix/index.ts
+++ b/packages/frontend/src/lib/radix/index.ts
@@ -1,6 +1,7 @@
 export * from "./Button";
 export * from "./Dialog";
 export * from "./Flex";
+export * from "./IconButton";
 export * from "./Select";
 export * from "./TextField";
 export * from "./SlideConfirm";
@@ -8,7 +9,6 @@ export * from "./ThreeButtonConfirm";
 
 export {
   Badge,
-  IconButton,
   ScrollArea,
   Spinner,
   Slider,


### PR DESCRIPTION
This pull request introduces functionality to delete snapshot states across the backend, API, and frontend layers. It also includes the creation of a reusable `IconButton` component for the frontend. Below is a summary of the most important changes:

### Backend and API Enhancements:
* Added `DeleteSnapshotStateRequest` and `deleteSnapshotState` endpoint to the `SnapshotStateApi` interface, enabling deletion of snapshot states. (`packages/api/services/snapshotState/snapshotStateService.ts`, [[1]](diffhunk://#diff-f3a13cc38b71f93505f3b495ace5a5982f63147b4ff98ca60dfbbec6d6a15c8eR45-R55) [[2]](diffhunk://#diff-f3a13cc38b71f93505f3b495ace5a5982f63147b4ff98ca60dfbbec6d6a15c8eR84)
* Implemented the `deleteSnapshotState` method in the `SnapshotStateController` to handle the new endpoint and call the service layer for deletion. (`packages/backend/src/snapshotState/snapshotState.controller.ts`, [packages/backend/src/snapshotState/snapshotState.controller.tsR51-R59](diffhunk://#diff-432bca2212347640cb227980b7868e6a2ec7418f89586e47705dd237c03654cfR51-R59))
* Added `deleteSnapshotState` method in the `SnapshotStateService` to interact with the database for snapshot deletion. (`packages/backend/src/snapshotState/snapshotState.service.ts`, [packages/backend/src/snapshotState/snapshotState.service.tsR223-R228](diffhunk://#diff-6ada1dcc7decbcfe7442e2c90faa3ff11d043967fc6a5f6a51873859c96c9f35R223-R228))

### Frontend Enhancements:
* Updated `OpenSnapshotState` component to include a delete button with a trash icon, allowing users to delete snapshot states. The UI updates the list of snapshots dynamically after deletion. (`packages/frontend/src/components/createGame/components/OpenSnapshotState.tsx`, [[1]](diffhunk://#diff-f80a17d987547fda90cf4d7bbeb1d0431f826ff80c59111c1947bc72a93526b3R63-R80) [[2]](diffhunk://#diff-f80a17d987547fda90cf4d7bbeb1d0431f826ff80c59111c1947bc72a93526b3R90-R114)

### Reusable Component:
* Created a reusable `IconButton` component in the `radix` library with associated styles, making it easier to implement icon-based buttons across the frontend. (`packages/frontend/src/lib/radix/IconButton.tsx`, [[1]](diffhunk://#diff-ed4b294cd4c1998349182e107406c829e5f54e9f37f9f58e38e7bd3f651489d5R1-R22); `packages/frontend/src/lib/radix/IconButton.module.scss`, [[2]](diffhunk://#diff-72de1d7221d66e53c9c8675d16fa34f8938c0aa447b31b96e092d6da56d23c1fR1-R5); `packages/frontend/src/lib/radix/index.ts`, [[3]](diffhunk://#diff-489341fc7d83449099663955ca24ca82e38b6ff45ff75c6da0a1974519aac6aaR4-L11)