### PR TITLE
Add words list to final score

### DIFF
--- a/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.module.scss
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.module.scss
@@ -1,5 +1,14 @@
 @use "@/styles/variables.scss" as vars;
 
-.scoreBox {
-    border-radius: 10px;
+.tab {
+    cursor: pointer;
+    
+    &:hover {
+        text-decoration: underline;
+    }
+
+    &.active {
+        text-decoration: underline;
+        color: vars.$blue;
+    }
 }

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.tsx
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.tsx
@@ -1,61 +1,50 @@
 import { DisplayText, Flex } from "@/lib/radix";
+import { Scoreboard } from "./finalScore/Scoreboard";
+import { selectTeamWithNames } from "../../../shared/globalSelectors";
 import { useFishbowlSelector } from "../../store/fishbowlRedux";
-import { finalScoreSelector } from "../../store/sharedSelectors";
-import { PlayerIcon } from "@/components/player/PlayerIcon";
-import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
-import styles from "./PlayerFinalScore.module.scss";
+import { useState } from "react";
 import { motion } from "motion/react";
+import styles from "./PlayerFinalScore.module.scss";
+import clsx from "clsx";
+import { PlayerContributions } from "./finalScore/PlayerContributions";
 
 export const PlayerFinalScore = () => {
-  const maybeFinalScores = useFishbowlSelector(finalScoreSelector);
+  const teamNames = useFishbowlSelector(selectTeamWithNames);
 
-  if (maybeFinalScores === undefined) {
-    return <Flex>Final scores not available yet.</Flex>;
-  }
-
-  const totalTeams = Object.keys(maybeFinalScores.teamEntries).length;
+  const [viewingTab, setViewingTab] = useState<
+    "scoreboard" | "player-contributions"
+  >("scoreboard");
 
   return (
-    <Flex align="center" direction="column" flex="1" justify="center">
-      <Flex direction="column" gap="5">
-        {maybeFinalScores.teamEntries.map((team, index) => (
-          <motion.div
-            animate={{ opacity: 1, y: 0 }}
-            initial={{ opacity: 0, y: 100 }}
-            key={team.teamName ?? index}
-            layout="position"
-            transition={{ delay: (totalTeams - index) * 1 }}
+    <Flex align="center" direction="column" flex="1" gap="4" justify="center">
+      <motion.div
+        animate={{ opacity: 1, y: 0 }}
+        initial={{ opacity: 0, y: 100 }}
+        transition={{ delay: (Object.keys(teamNames ?? {}).length ?? 0) + 1 }}
+      >
+        <Flex align="center" gap="3">
+          <Flex
+            className={clsx(
+              styles.tab,
+              viewingTab === "scoreboard" && styles.active
+            )}
+            onClick={() => setViewingTab("scoreboard")}
           >
-            <Flex
-              className={styles.scoreBox}
-              direction="column"
-              flex="1"
-              gap="3"
-              key={index}
-              p="4"
-              style={{ background: getTeamColor(team.players[0]?.team ?? 0) }}
-            >
-              <Flex align="center" flex="1" gap="5" justify="between" pb="4">
-                <Flex gap="3">
-                  {index === 0 && <DisplayText size="7">👑</DisplayText>}
-                  <DisplayText size="7">{team.teamName}</DisplayText>
-                </Flex>
-                <DisplayText ml="5" size="7">
-                  {team.totalScore}
-                </DisplayText>
-              </Flex>
-              <Flex gap="2" wrap="wrap">
-                {team.players.map((player) => (
-                  <Flex align="center" gap="2" key={player.playerId}>
-                    <PlayerIcon dimension={25} player={player} />
-                    <DisplayText size="5">{player.displayName}</DisplayText>
-                  </Flex>
-                ))}
-              </Flex>
-            </Flex>
-          </motion.div>
-        ))}
-      </Flex>
+            <DisplayText>Scoreboard</DisplayText>
+          </Flex>
+          <Flex
+            className={clsx(
+              styles.tab,
+              viewingTab === "player-contributions" && styles.active
+            )}
+            onClick={() => setViewingTab("player-contributions")}
+          >
+            <DisplayText>Words</DisplayText>
+          </Flex>
+        </Flex>
+      </motion.div>
+      {viewingTab === "scoreboard" && <Scoreboard />}
+      {viewingTab === "player-contributions" && <PlayerContributions />}
     </Flex>
   );
 };

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/PlayerContribution.module.scss
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/PlayerContribution.module.scss
@@ -1,0 +1,18 @@
+@use "@/styles/variables.scss" as vars;
+
+.container {
+    overflow-y: auto;
+    max-height: 85vh;
+}
+
+.scrollable {
+    padding-bottom: 150px;
+    height: fit-content;
+}
+
+.singleWord {
+    border-radius: 5px;
+    border: 1px solid vars.$black;
+    background: vars.$white;
+    max-width: 75vw;
+}

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/PlayerContributions.tsx
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/PlayerContributions.tsx
@@ -1,0 +1,33 @@
+import { DisplayText, Flex } from "@/lib/radix";
+import { selectAllPlayerContributions } from "../../selectors/playerSelectors";
+import { useFishbowlSelector } from "../../../store/fishbowlRedux";
+import styles from "./PlayerContribution.module.scss";
+import { PlayerIcon } from "@/components/player/PlayerIcon";
+
+export const PlayerContributions = () => {
+  const contributions = useFishbowlSelector(selectAllPlayerContributions);
+
+  return (
+    <Flex className={styles.container}>
+      <Flex className={styles.scrollable} direction="column" gap="2">
+        {contributions?.map((contribution) => (
+          <Flex
+            className={styles.singleWord}
+            direction="column"
+            gap="1"
+            key={contribution.word}
+            p="2"
+          >
+            <DisplayText size="5">{contribution.word}</DisplayText>
+            <Flex align="center" gap="2">
+              <PlayerIcon dimension={20} player={contribution.contributedBy} />
+              <DisplayText size="3">
+                {contribution.contributedBy.displayName}
+              </DisplayText>
+            </Flex>
+          </Flex>
+        ))}
+      </Flex>
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/Scoreboard.module.scss
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/Scoreboard.module.scss
@@ -1,0 +1,5 @@
+@use "@/styles/variables.scss" as vars;
+
+.scoreBox {
+    border-radius: 10px;
+}

--- a/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/Scoreboard.tsx
+++ b/packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/Scoreboard.tsx
@@ -1,0 +1,59 @@
+import { PlayerIcon } from "@/components/player/PlayerIcon";
+import { getTeamColor } from "@/lib/stableIdentifiers/teamIdentifier";
+import { motion } from "motion/react";
+import { DisplayText, Flex } from "../../../../../../lib/radix";
+import { useFishbowlSelector } from "../../../store/fishbowlRedux";
+import { finalScoreSelector } from "../../../store/sharedSelectors";
+import styles from "./Scoreboard.module.scss";
+
+export const Scoreboard = () => {
+  const maybeFinalScores = useFishbowlSelector(finalScoreSelector);
+
+  if (maybeFinalScores === undefined) {
+    return <Flex>Final scores not available yet.</Flex>;
+  }
+
+  const totalTeams = Object.keys(maybeFinalScores.teamEntries).length;
+
+  return (
+    <Flex direction="column" gap="5">
+      {maybeFinalScores.teamEntries.map((team, index) => (
+        <motion.div
+          animate={{ opacity: 1, y: 0 }}
+          initial={{ opacity: 0, y: 100 }}
+          key={team.teamName ?? index}
+          layout="position"
+          transition={{ delay: (totalTeams - index) * 1 }}
+        >
+          <Flex
+            className={styles.scoreBox}
+            direction="column"
+            flex="1"
+            gap="3"
+            key={index}
+            p="4"
+            style={{ background: getTeamColor(team.players[0]?.team ?? 0) }}
+          >
+            <Flex align="center" flex="1" gap="5" justify="between" pb="4">
+              <Flex gap="3">
+                {index === 0 && <DisplayText size="7">👑</DisplayText>}
+                <DisplayText size="7">{team.teamName}</DisplayText>
+              </Flex>
+              <DisplayText ml="5" size="7">
+                {team.totalScore}
+              </DisplayText>
+            </Flex>
+            <Flex gap="2" wrap="wrap">
+              {team.players.map((player) => (
+                <Flex align="center" gap="2" key={player.playerId}>
+                  <PlayerIcon dimension={25} player={player} />
+                  <DisplayText size="5">{player.displayName}</DisplayText>
+                </Flex>
+              ))}
+            </Flex>
+          </Flex>
+        </motion.div>
+      ))}
+    </Flex>
+  );
+};

--- a/packages/games/src/frontend/fishbowl/playerComponents/selectors/playerSelectors.ts
+++ b/packages/games/src/frontend/fishbowl/playerComponents/selectors/playerSelectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit";
-import { FishbowlGameConfiguration } from "../../../../backend";
+import { FishbowlGameConfiguration, FishbowlWord } from "../../../../backend";
 import { FishbowlReduxState } from "../../store/fishbowlRedux";
 
 export const selectFishbowlPlayer = createSelector(
@@ -100,5 +100,26 @@ export const selectNewPlayerGuess = createSelector(
       player: allPlayers?.find((p) => p.playerId === player.playerId),
       roundNumber: round.roundNumber
     };
+  }
+);
+
+export const selectAllPlayerContributions = createSelector(
+  [
+    (state: FishbowlReduxState) =>
+      state.gameStateSlice.gameState?.playerWordContributions,
+    (state: FishbowlReduxState) => state.gameStateSlice.gameInfo?.players
+  ],
+  (contributions, players) => {
+    if (contributions === undefined || players === undefined) {
+      return;
+    }
+
+    const allWords = Object.values(contributions).flatMap(
+      ({ words }): FishbowlWord[] => words
+    );
+
+    allWords.sort((a, b) => a.word.localeCompare(b.word));
+
+    return allWords;
   }
 );


### PR DESCRIPTION
This pull request introduces a tabbed interface for the final score screen in the Fishbowl game, allowing users to toggle between a "Scoreboard" view and a "Player Contributions" view. It also includes new components and styles to support this functionality.

### Tabbed Interface and Component Refactor:
* Updated `PlayerFinalScore.tsx` to include a tabbed interface for switching between the "Scoreboard" and "Player Contributions" views. This refactor replaces the previous single-view implementation. (`[packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.tsxR2-R47](diffhunk://#diff-74e78d8c328b53decdb3bae46b8cf965982edeb249fa7c66ada8967f5fff4f09R2-R47)`)
* Introduced the `Scoreboard` component to display team scores, extracted from the original `PlayerFinalScore` implementation. (`[packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/Scoreboard.tsxR1-R59](diffhunk://#diff-e82885f473c12474af57f7980d0aa888a8df9673d02d372d331a196f9dc455edR1-R59)`)
* Added the `PlayerContributions` component to display individual player word contributions, including a scrollable layout. (`[packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/PlayerContributions.tsxR1-R33](diffhunk://#diff-356f7bd31109310c094b75bd5db1ec9e5a6046ff7335177bdb083e3b7afba484R1-R33)`)

### Styling Updates:
* Replaced the `.scoreBox` class with the `.tab` class in `PlayerFinalScore.module.scss`, adding hover and active states for tabs. (`[packages/games/src/frontend/fishbowl/playerComponents/components/PlayerFinalScore.module.scssL3-R13](diffhunk://#diff-19faa60cba3550b589301eea131ddb1471d1c7e8e1baf405a3d4b093fb69ddf5L3-R13)`)
* Added new styles for `PlayerContribution.module.scss` to support the scrollable container and individual word display. (`[packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/PlayerContribution.module.scssR1-R18](diffhunk://#diff-d419b6e92337e5e49052a1a6f77775ad5eebd256d29a9a1d74c1cae9f4b46aa3R1-R18)`)
* Added minimal styling for the `Scoreboard` component in `Scoreboard.module.scss`. (`[packages/games/src/frontend/fishbowl/playerComponents/components/finalScore/Scoreboard.module.scssR1-R5](diffhunk://#diff-f43b60fb28c3fc32dc837dd79b52f00c31cab952969435d6c6a7944b708728d1R1-R5)`)

### Redux Selector Enhancements:
* Added a new selector, `selectAllPlayerContributions`, to retrieve and sort player word contributions for the "Player Contributions" view. (`[packages/games/src/frontend/fishbowl/playerComponents/selectors/playerSelectors.tsR105-R125](diffhunk://#diff-891390a2f539ccf9a9eb817646c01379113ad7ef857dd7f92e0fd987d78058d7R105-R125)`)